### PR TITLE
Move clusterissuer NP and PSP to post-install hook

### DIFF
--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/np.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/np.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.name }}
   namespace: {{ .Values.namespace }}
   annotations:
-    "helm.sh/hook": "pre-install"
+    "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": "hook-succeeded"
   labels:

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/psp.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/psp.yaml
@@ -3,7 +3,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ .Values.name }}
   annotations:
-    "helm.sh/hook": "pre-install"
+    "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": "hook-succeeded"
   labels:


### PR DESCRIPTION
It's not clear to me whether this is a change in Helm between 2.14 and 2.16 or if it only surfaced due to the default deny-all network policy in the 1.16 release, but cert-manager-giantswarm-clusterissuer is unable to communicate with the Kubernetes API as its network policy in the pre-install hook is deleted before it runs in the post-install hook. See the tiller logs in the comment below for more info.

I have a similar PR for kiam-app here https://github.com/giantswarm/kiam-app/pull/10 since it was showing similar behavior on AWS 1.16 clusters. I'm not sure if any other apps need to be updated.