### PR TITLE
Fixing invalid ClusterRoleBinding

### DIFF
--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/rbac.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/rbac.yaml
@@ -55,5 +55,4 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: {{ .Values.name }}
-  namespace: {{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
ClusterRoleBinding do not support namespaces in the roleref section. Installing the chart resulted in an error