### PR TITLE
don't attempt to install CRDs during upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Install CRDs during chart installation only. ([#46](https://github.com/giantswarm/cert-manager-app/pull/46))
+
 ## [2.0.1] - 2020-07-28
 
 ### Changed

--- a/helm/cert-manager-app/templates/_helpers.tpl
+++ b/helm/cert-manager-app/templates/_helpers.tpl
@@ -37,7 +37,7 @@ giantswarm.io/service-type: "managed"
 {{- end -}}
 
 {{- define "certManager.CRDInstallAnnotations" -}}
-"helm.sh/hook": "pre-install,pre-upgrade"
+"helm.sh/hook": "pre-install"
 "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
 {{- end -}}
 


### PR DESCRIPTION
we should only attempt to install CRDs on initial chart installation as it causes chart upgrades to fail.
