### PR TITLE
Upgrade to 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update cert-manager from upstream 0.15.2 to 0.16.1. ([#51](https://github.com/giantswarm/cert-manager-app/pull/51))
+
 ## [2.0.2] - 2020-07-29
 
 ### Changed

--- a/helm/cert-manager-app/Chart.yaml
+++ b/helm/cert-manager-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.16.0
+appVersion: 0.16.1
 description: A Helm chart for cert-manager
 engine: gotpl
 home: https://github.com/giantswarm/cert-manager-app

--- a/helm/cert-manager-app/Chart.yaml
+++ b/helm/cert-manager-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.15.2
+appVersion: 0.16.0
 description: A Helm chart for cert-manager
 engine: gotpl
 home: https://github.com/giantswarm/cert-manager-app

--- a/helm/cert-manager-app/templates/cainjector-deployment.yaml
+++ b/helm/cert-manager-app/templates/cainjector-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         runAsGroup: {{ .Values.global.securityContext.groupID }}
       containers:
         - name: cainjector
-          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-cainjector:v0.15.2"
+          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-cainjector:v0.16.0"
           imagePullPolicy: {{ .Values.cainjector.image.pullPolicy }}
           args:
           - --v={{ .Values.cainjector.logLevel | default 2 }}

--- a/helm/cert-manager-app/templates/cainjector-deployment.yaml
+++ b/helm/cert-manager-app/templates/cainjector-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         runAsGroup: {{ .Values.global.securityContext.groupID }}
       containers:
         - name: cainjector
-          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-cainjector:v0.16.0"
+          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-cainjector:v0.16.1"
           imagePullPolicy: {{ .Values.cainjector.image.pullPolicy }}
           args:
           - --v={{ .Values.cainjector.logLevel | default 2 }}

--- a/helm/cert-manager-app/templates/controller-deployment.yaml
+++ b/helm/cert-manager-app/templates/controller-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         runAsGroup: {{ .Values.global.securityContext.groupID }}
       containers:
         - name: cert-manager
-          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-controller:v0.15.2"
+          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-controller:v0.16.0"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)

--- a/helm/cert-manager-app/templates/controller-deployment.yaml
+++ b/helm/cert-manager-app/templates/controller-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         runAsGroup: {{ .Values.global.securityContext.groupID }}
       containers:
         - name: cert-manager
-          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-controller:v0.16.0"
+          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-controller:v0.16.1"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)

--- a/helm/cert-manager-app/templates/webhook-deployment.yaml
+++ b/helm/cert-manager-app/templates/webhook-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: {{ template "certManager.name.webhook" . }}
       containers:
         - name: webhook
-          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-webhook:v0.16.0"
+          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-webhook:v0.16.1"
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
           args:
           - --v={{ .Values.webhook.logLevel | default 2 }}

--- a/helm/cert-manager-app/templates/webhook-deployment.yaml
+++ b/helm/cert-manager-app/templates/webhook-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: {{ template "certManager.name.webhook" . }}
       containers:
         - name: webhook
-          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-webhook:v0.15.2"
+          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-webhook:v0.16.0"
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
           args:
           - --v={{ .Values.webhook.logLevel | default 2 }}


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/12549

- [x] deploy to local kind cluster
- [x] deploy to g8s cluster as optional app
  - [x] test ingresses can request certs successfully
- [x] deploy to aws nodepool cluster as pre-installed app
  - [x] test ingresses can request certs successfully
  - [x] test dependent apps also work (kiam & external-dns)
- [x] test upgrading from 0.15.x