### PR TITLE
re-introduce pre-upgrade hook for CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Re-introduced hook to allow for CRD install during app upgrades ([#55](https://github.com/giantswarm/cert-manager-app/pull/55))
+
 ## [2.1.0] - 2020-08-11
 
 ### Changed

--- a/helm/cert-manager-app/templates/_helpers.tpl
+++ b/helm/cert-manager-app/templates/_helpers.tpl
@@ -37,7 +37,7 @@ giantswarm.io/service-type: "managed"
 {{- end -}}
 
 {{- define "certManager.CRDInstallAnnotations" -}}
-"helm.sh/hook": "pre-install"
+"helm.sh/hook": "pre-install,pre-upgrade"
 "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
 {{- end -}}
 


### PR DESCRIPTION
We should always attempt to upgrade CRDs when the app is upgraded.
