### PR TITLE
Unique names for hook resources

### DIFF
--- a/helm/cert-manager-app/charts/crd-install-cleanup/Chart.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+appVersion: 0.16.1
+description: A Helm chart to clean up any resources from the crd-install hook.
+engine: gotpl
+home: https://github.com/giantswarm/cert-manager-app
+icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+name: crd-install-cleanup
+sources:
+- https://github.com/giantswarm/cert-manager-app
+version: 1.0.0

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/job.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/job.yaml
@@ -23,6 +23,7 @@ spec:
           - delete
           - -n
           - {{ .Release.Namespace }}
+          - job,configmap,clusterrolebinding,clusterrole,networkpolicy,podsecuritypolicy,serviceaccount
           - -l
           - role={{ template "certManager.CRDInstallSelector" . }}
         resources: {{- toYaml .Values.resources | nindent 10 }}

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/job.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/job.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ .Values.name }}
+      securityContext:
+        runAsUser: {{ .Values.userID }}
+        runAsGroup: {{ .Values.groupID }}
+      containers:
+      - name: {{ .Values.name }}
+        image: "{{ .Values.global.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        args:
+          - delete
+          - -n
+          - {{ .Release.Namespace }}
+          - -l
+          - role={{ template "certManager.CRDInstallSelector" . }}
+        resources: {{- toYaml .Values.resources | nindent 10 }}
+      restartPolicy: Never
+  backoffLimit: 4

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/job.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/job.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/job.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/job.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/np.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/np.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/np.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/np.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/np.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/np.yaml
@@ -1,0 +1,34 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+spec:
+  podSelector:
+    matchLabels:
+      job-name: {{ .Values.name }}
+  # allow egress traffic to the Kubernetes API
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    # legacy port kept for compatibility
+    - port: 6443
+      protocol: TCP
+    to:
+    {{- range tuple "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" "100.64.0.0/10" }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+  # deny all ingress traffic
+  ingress: []
+  policyTypes:
+  - Egress
+  - Ingress

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/psp.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/psp.yaml
@@ -1,0 +1,32 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Values.name }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+spec:
+  privileged: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  volumes: []
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/psp.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/psp.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/psp.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/psp.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/rbac.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"
@@ -120,6 +121,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/rbac.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/rbac.yaml
@@ -10,8 +10,8 @@ metadata:
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"
-# allow deletion of all resource types created by crd-install hook
 rules:
+# allow hook to get/list all cm,sa
 - apiGroups:
   - ""
   resources:
@@ -19,28 +19,80 @@ rules:
   - "serviceaccounts"
   verbs:
   - "get"
+  - "list"
+# allow hook to delete only the crdinstall cm,sa
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  - "serviceaccounts"
+  verbs:
   - "delete"
   resourceNames:
   - "{{ template "certManager.name.crdInstall" . }}"
+# allow hook to get/list all jobs
 - apiGroups:
   - "batch"
   resources:
   - "jobs"
   verbs:
   - "get"
+  - "list"
+# allow hook to delete only the crdinstall job
+- apiGroups:
+  - "batch"
+  resources:
+  - "jobs"
+  verbs:
   - "delete"
   resourceNames:
   - "{{ template "certManager.name.crdInstall" . }}"
+# allow hook to get/list all netpol
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - "networkpolicies"
+  verbs:
+  - "get"
+  - "list"
+# allow hook to delete only the crdinstall netpol
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - "networkpolicies"
+  verbs:
+  - "get"
+  - "delete"
+  resourceNames:
+  - "{{ template "certManager.name.crdInstall" . }}"
+# allow hook to get/list all psp
 - apiGroups:
   - "policy"
   resources:
-  - "networkpolicies"
+  - "podsecuritypolicies"
+  verbs:
+  - "get"
+  - "list"
+# allow hook to delete only the crdinstall psp
+- apiGroups:
+  - "policy"
+  resources:
   - "podsecuritypolicies"
   verbs:
   - "get"
   - "delete"
   resourceNames:
   - "{{ template "certManager.name.crdInstall" . }}"
+# allow hook to get/list all clusterrole/clusterrolebinding
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - "clusterroles"
+  - "clusterrolebindings"
+  verbs:
+  - "get"
+  - "list"
+# allow hook to delete only the crdinstall clusterrole/clusterrolebinding
 - apiGroups:
   - "rbac.authorization.k8s.io"
   resources:
@@ -51,7 +103,7 @@ rules:
   - "delete"
   resourceNames:
   - "{{ template "certManager.name.crdInstall" . }}"
-# allow the role to use the subchart's PSP
+# allow hook to use its own psp
 - apiGroups:
   - policy
   resources:

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/rbac.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/rbac.yaml
@@ -61,7 +61,6 @@ rules:
   resources:
   - "networkpolicies"
   verbs:
-  - "get"
   - "delete"
   resourceNames:
   - "{{ template "certManager.name.crdInstall" . }}"
@@ -79,7 +78,6 @@ rules:
   resources:
   - "podsecuritypolicies"
   verbs:
-  - "get"
   - "delete"
   resourceNames:
   - "{{ template "certManager.name.crdInstall" . }}"
@@ -99,7 +97,6 @@ rules:
   - "clusterroles"
   - "clusterrolebindings"
   verbs:
-  - "get"
   - "delete"
   resourceNames:
   - "{{ template "certManager.name.crdInstall" . }}"

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/rbac.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/rbac.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"
@@ -121,7 +120,6 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/rbac.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/rbac.yaml
@@ -120,7 +120,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/rbac.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/rbac.yaml
@@ -1,0 +1,83 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+# allow deletion of all resource types created by crd-install hook
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  - "serviceaccounts"
+  verbs:
+  - "get"
+  - "delete"
+  resourceNames:
+  - "{{ template "certManager.name.crdInstall" . }}"
+- apiGroups:
+  - "batch"
+  resources:
+  - "jobs"
+  verbs:
+  - "get"
+  - "delete"
+  resourceNames:
+  - "{{ template "certManager.name.crdInstall" . }}"
+- apiGroups:
+  - "policy"
+  resources:
+  - "networkpolicies"
+  - "podsecuritypolicies"
+  verbs:
+  - "get"
+  - "delete"
+  resourceNames:
+  - "{{ template "certManager.name.crdInstall" . }}"
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - "clusterroles"
+  - "clusterrolebindings"
+  verbs:
+  - "get"
+  - "delete"
+  resourceNames:
+  - "{{ template "certManager.name.crdInstall" . }}"
+# allow the role to use the subchart's PSP
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ .Values.name }}
+  verbs:
+  - "use"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.name }}
+  apiGroup: rbac.authorization.k8s.io

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/service-account.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/service-account.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/service-account.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/service-account.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.name }}

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/service-account.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/service-account.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.name }}

--- a/helm/cert-manager-app/charts/crd-install-cleanup/values.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/values.yaml
@@ -1,0 +1,17 @@
+name: crd-install-cleanup
+
+userID: 1000
+groupID: 1000
+
+image:
+  registry: quay.io
+  name: giantswarm/docker-kubectl
+  tag: latest
+
+resources:
+  limits:
+    cpu: 50m
+    memory: 75Mi
+  requests:
+    cpu: 50m
+    memory: 75Mi

--- a/helm/cert-manager-app/templates/_helpers.tpl
+++ b/helm/cert-manager-app/templates/_helpers.tpl
@@ -65,3 +65,8 @@ giantswarm.io/service-type: "managed"
 app.kubernetes.io/name: "{{ template "certManager.name" . }}"
 app.kubernetes.io/instance: "{{ template "certManager.name" . }}"
 {{- end -}}
+
+{{/* Create a label which can be used to select any orphaned crd-install hook resources */}}
+{{- define "certManager.CRDInstallSelector" -}}
+{{- printf "%s" "crd-install-hook" -}}
+{{- end -}}

--- a/helm/cert-manager-app/templates/_helpers.tpl
+++ b/helm/cert-manager-app/templates/_helpers.tpl
@@ -20,7 +20,7 @@
 {{- printf "%s-%s" ( include "certManager.name" . ) "controller" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{*/
+{{/*
 Create a unique name for crd-install hook resource names. We don't truncate
 it as we don't want to lose the end of the epoch time - this is what makes
 the name unique.

--- a/helm/cert-manager-app/templates/_helpers.tpl
+++ b/helm/cert-manager-app/templates/_helpers.tpl
@@ -5,6 +5,12 @@
 {{- default .Chart.Name .Values.global.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/* Generate a string containing the current Unix time for appending to CRD install resource names. */}}
+{{- define "unixTime.now" -}}
+{{- $time := now | unixEpoch }}
+{{- printf "%s" $time -}}
+{{- end -}}
+
 {{/* Create names for each component to avoid repetition. */}}
 {{- define "certManager.name.cainjector" -}}
 {{- printf "%s-%s" (include "certManager.name" . ) "cainjector" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}

--- a/helm/cert-manager-app/templates/_helpers.tpl
+++ b/helm/cert-manager-app/templates/_helpers.tpl
@@ -20,8 +20,13 @@
 {{- printf "%s-%s" ( include "certManager.name" . ) "controller" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{*/
+Create a unique name for crd-install hook resource names. We don't truncate
+it as we don't want to lose the end of the epoch time - this is what makes
+the name unique.
+*/}}
 {{- define "certManager.name.crdInstall" -}}
-{{- printf "%s-%s" ( include "certManager.name" . ) "crd-install" | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-%s" ( include "certManager.name" . ) "crd-install" ( include "unixTime.now" . ) | replace "+" "_" | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "certManager.name.webhook" -}}

--- a/helm/cert-manager-app/templates/crd-configmap.yaml
+++ b/helm/cert-manager-app/templates/crd-configmap.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/component: "{{ template "certManager.name.crdInstall" . }}"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
+    {{- include "certManager.CRDInstallSelector" . | nindent 4 }}
 data:
   crds.yaml: |
 {{ tpl ( .Files.Get "files/crds.yaml" ) . | indent 4 }}

--- a/helm/cert-manager-app/templates/crd-configmap.yaml
+++ b/helm/cert-manager-app/templates/crd-configmap.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/component: "{{ template "certManager.name.crdInstall" . }}"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
-    {{- include "certManager.CRDInstallSelector" . | nindent 4 }}
+    role: "{{ template "certManager.CRDInstallSelector" . }}"
 data:
   crds.yaml: |
 {{ tpl ( .Files.Get "files/crds.yaml" ) . | indent 4 }}

--- a/helm/cert-manager-app/templates/crd-job.yaml
+++ b/helm/cert-manager-app/templates/crd-job.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/component: "{{ template "certManager.name.crdInstall" . }}"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
+    {{- include "certManager.CRDInstallSelector" . | nindent 4 }}
 spec:
   template:
     metadata:

--- a/helm/cert-manager-app/templates/crd-job.yaml
+++ b/helm/cert-manager-app/templates/crd-job.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/component: "{{ template "certManager.name.crdInstall" . }}"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
-    {{- include "certManager.CRDInstallSelector" . | nindent 4 }}
+    role: "{{ template "certManager.CRDInstallSelector" . }}"
 spec:
   template:
     metadata:

--- a/helm/cert-manager-app/templates/crd-np.yaml
+++ b/helm/cert-manager-app/templates/crd-np.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/component: "{{ template "certManager.name.crdInstall" . }}"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
-    {{- include "certManager.CRDInstallSelector" . | nindent 4 }}
+    role: "{{ template "certManager.CRDInstallSelector" . }}"
 spec:
   podSelector:
     matchLabels:

--- a/helm/cert-manager-app/templates/crd-np.yaml
+++ b/helm/cert-manager-app/templates/crd-np.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/component: "{{ template "certManager.name.crdInstall" . }}"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
+    {{- include "certManager.CRDInstallSelector" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/helm/cert-manager-app/templates/crd-psp.yaml
+++ b/helm/cert-manager-app/templates/crd-psp.yaml
@@ -6,10 +6,11 @@ metadata:
   annotations:
     # create hook dependencies in the right order
     "helm.sh/hook-weight": "-6"
-    {{- include "certManager.CRDInstallAnnotations" . | nindent 4 }}  
+    {{- include "certManager.CRDInstallAnnotations" . | nindent 4 }}
   labels:
     app.kubernetes.io/component: "{{ template "certManager.name.crdInstall" . }}"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
+    {{- include "certManager.CRDInstallSelector" . | nindent 4 }}
 spec:
   privileged: false
   runAsUser:

--- a/helm/cert-manager-app/templates/crd-psp.yaml
+++ b/helm/cert-manager-app/templates/crd-psp.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app.kubernetes.io/component: "{{ template "certManager.name.crdInstall" . }}"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
-    {{- include "certManager.CRDInstallSelector" . | nindent 4 }}
+    role: "{{ template "certManager.CRDInstallSelector" . }}"
 spec:
   privileged: false
   runAsUser:

--- a/helm/cert-manager-app/templates/crd-rbac.yaml
+++ b/helm/cert-manager-app/templates/crd-rbac.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/component: "{{ template "certManager.name.crdInstall" . }}"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
+    {{- include "certManager.CRDInstallSelector" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/helm/cert-manager-app/templates/crd-rbac.yaml
+++ b/helm/cert-manager-app/templates/crd-rbac.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/component: "{{ template "certManager.name.crdInstall" . }}"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
-    {{- include "certManager.CRDInstallSelector" . | nindent 4 }}
+    role: "{{ template "certManager.CRDInstallSelector" . }}"
 rules:
 - apiGroups:
   - ""

--- a/helm/cert-manager-app/templates/crd-serviceaccount.yaml
+++ b/helm/cert-manager-app/templates/crd-serviceaccount.yaml
@@ -11,5 +11,5 @@ metadata:
   labels:
     app.kubernetes.io/component: "{{ template "certManager.name.crdInstall" . }}"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
-    {{- include "certManager.CRDInstallSelector" . | nindent 4 }}
+    role: "{{ template "certManager.CRDInstallSelector" . }}"
 {{- end }}

--- a/helm/cert-manager-app/templates/crd-serviceaccount.yaml
+++ b/helm/cert-manager-app/templates/crd-serviceaccount.yaml
@@ -11,4 +11,5 @@ metadata:
   labels:
     app.kubernetes.io/component: "{{ template "certManager.name.crdInstall" . }}"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
+    {{- include "certManager.CRDInstallSelector" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/12798

Using the current unix time is the best way I can find to make the resource names unique. Using a random string doesn't work because each time the template is called, the string is different.

In order to avoid orphaned resources being left behind, I've also added a label which can be used to select all crd hook resources - these are used by a new sub-chart which runs at the post-install and post-upgrade stages which deletes all resources with this label.

The subchart's RBAC rules are as restrictive as possible - the pod can only list the resource types it needs, and it can only delete the named resources.