### PR TITLE
Fix secret name for orders.acme.cert-manager.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix secret name for `orders.acme.cert-manager.io` CR, allowing proper CA injection. ([#60](https://github.com/giantswarm/cert-manager-app/pull/60))
+
 ## [2.1.1] - 2020-08-19
 
 ### Changed

--- a/helm/cert-manager-app/files/crds.yaml
+++ b/helm/cert-manager-app/files/crds.yaml
@@ -1806,7 +1806,7 @@ kind: CustomResourceDefinition
 metadata:
   name: orders.acme.cert-manager.io
   annotations:
-    cert-manager.io/inject-ca-from-secret: '{{ .Release.Namespace }}/{{ template "certManager.name.webhook" . }}ca'
+    cert-manager.io/inject-ca-from-secret: '{{ .Release.Namespace }}/{{ template "certManager.name.webhook" . }}-ca'
   labels:
     {{- include "certManager.CRDLabels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Towards giantswarm/giantswarm#12935

Missing dash prevented `orders.acme.cert-manager.io` CR from being requested/created with the following error
```
Error from server: conversion webhook for acme.cert-manager.io/v1alpha2, Kind=Order failed: Post https://cert-manager-webhook.giantswarm.svc:443/convert?timeout=30s: x509: certificate signed 
by unknown authority  
```