### PR TITLE
drop resource limit for clusterissuer subchart job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Drop resource limits from `ClusterIssuer` subchart to stop it running out of memory. ([#63](https://github.com/giantswarm/cert-manager-app/pull/63))
+
+### Fixed
+
+- Allow `crd-install` job to patch Custom Resource Definitons. ([#62](https://github.com/giantswarm/cert-manager-app/pull/62))
+
 ## [2.1.2] - 2020-09-04
 
 ### Fixed

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/values.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/values.yaml
@@ -13,9 +13,6 @@ image:
   tag: latest
 
 resources:
-  limits:
-    cpu: 100m
-    memory: 150Mi
   requests:
     cpu: 50m
     memory: 75Mi

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/values.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/values.yaml
@@ -14,8 +14,8 @@ image:
 
 resources:
   limits:
-    cpu: 50m
-    memory: 75Mi
+    cpu: 100m
+    memory: 150Mi
   requests:
     cpu: 50m
     memory: 75Mi


### PR DESCRIPTION
towards giantswarm/giantswarm/issues/13119

drop the pod resource limits to stop it being killed when running on CPs
