### PR TITLE
Update clusterissuer subchart rbac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Chaned
+
+- Allow clusterissuer subchart to patch clusterissuer resources. ([#65](https://github.com/giantswarm/cert-manager-app/pull/65))
+
 ## [2.1.3] - 2020-09-04
 
 ### Changed

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/rbac.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/rbac.yaml
@@ -28,6 +28,7 @@ rules:
   - "create"
   - "delete"
   - "get"
+  - "patch"
 - apiGroups:
   - policy
   resources:


### PR DESCRIPTION
```
for: "/data/clusterissuer": clusterissuers.cert-manager.io "selfsigned-giantswarm" is forbidden: User "system:serviceaccount:kube-system:cert-manager-giantswarm-clusterissuer" cannot patch resource "clusterissuers" in API group "cert-manager.io" at the cluster scope
```
