### PR TITLE
Disable push to CP app-catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,51 +36,6 @@ workflows:
             tags:
               only: /^v.*/
 
-      # deploy to aws installations (only tags)
-      - architect/push-to-app-collection:
-          name: push-cert-manager-app-to-aws-app-collection
-          app_name: "cert-manager-app"
-          app_namespace: "kube-system"
-          app_collection_repo: "aws-app-collection"
-          unique: "true"
-          requires:
-            - push-cert-manager-app-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      # deploy to azure installations (only tags)
-      - architect/push-to-app-collection:
-          name: push-cert-manager-app-to-azure-app-collection
-          app_name: "cert-manager-app"
-          app_namespace: "kube-system"
-          app_collection_repo: "azure-app-collection"
-          unique: "true"
-          requires:
-            - push-cert-manager-app-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      # deploy to kvm installations (only tags)
-      - architect/push-to-app-collection:
-          name: push-cert-manager-app-to-kvm-app-collection
-          app_name: "cert-manager-app"
-          app_namespace: "kube-system"
-          app_collection_repo: "kvm-app-collection"
-          unique: "true"
-          requires:
-            - push-cert-manager-app-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
       - architect/integration-test:
           name: basic-integration-test
           test-dir: "integration/test/basic"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [2.1.4] - 2020-09-07
 
-### Chaned
+### Changed
 
 - Allow clusterissuer subchart to patch clusterissuer resources. ([#65](https://github.com/giantswarm/cert-manager-app/pull/65))
 


### PR DESCRIPTION
This is a temporary precaution until I fix issues when upgrading cert-manager-app on CPs.