### PR TITLE
Add optional Kiam annotation for Route53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add an optional Kiam annotation in case that Route53 wants to be used.
+
 ## [2.1.4] - 2020-09-07
 
 ### Changed

--- a/helm/cert-manager-app/templates/controller-deployment.yaml
+++ b/helm/cert-manager-app/templates/controller-deployment.yaml
@@ -23,6 +23,9 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9402'
       {{- end }}
+      {{- if .Values.controller.aws.role }}
+      iam.amazonaws.com/role: {{ .Values.controller.aws.role }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "certManager.name.controller" . }}
       securityContext:

--- a/helm/cert-manager-app/templates/controller-deployment.yaml
+++ b/helm/cert-manager-app/templates/controller-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         prometheus.io/port: '9402'
       {{- end }}
       {{- if .Values.controller.aws.role }}
-      iam.amazonaws.com/role: {{ .Values.controller.aws.role }}
+        iam.amazonaws.com/role: {{ .Values.controller.aws.role }}
       {{- end }}
     spec:
       serviceAccountName: {{ template "certManager.name.controller" . }}

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -44,6 +44,10 @@ cainjector:
 # controller
 controller:
 
+  # AWS parameters to configure cert manager to work with Route53
+  aws:
+    role: "" # Role name used to authN cert manager against AWS API
+
   # controller.defaultIssuer
   # Sets the default certificate issuer; this behaviour can be disabled by setting
   # controller.defaultIssuer to an empty dictionary e.g. `controller.defaultIssuer: {}`.

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -46,7 +46,9 @@ controller:
 
   # AWS parameters to configure cert manager to work with Route53
   aws:
-    role: "" # Role name used to authN cert manager against AWS API
+
+    # Role name used to authenticate cert manager against AWS API
+    role: ""
 
   # controller.defaultIssuer
   # Sets the default certificate issuer; this behaviour can be disabled by setting


### PR DESCRIPTION
Configure cert manager to be able to use Route53 for DNS01 challenages