### PR TITLE
Clean up resources after hooks are finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `hook-delete-policy` to delete hook resources to make upgrades reliable.
+
 ## [2.2.4] - 2020-09-29
 
 ### Added

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/job.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/job.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/np.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/np.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/psp.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/psp.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/rbac.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"
@@ -118,7 +118,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/crd-install-cleanup/templates/service-account.yaml
+++ b/helm/cert-manager-app/charts/crd-install-cleanup/templates/service-account.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.name }}

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/cm.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/cm.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/cm.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/cm.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/job.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/job.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/job.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/job.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/np.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/np.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/np.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/np.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/psp.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/psp.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/psp.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/psp.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/rbac.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/rbac.yaml
@@ -46,7 +46,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/rbac.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"
@@ -46,7 +46,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/service-account.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/service-account.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.name }}

--- a/helm/cert-manager-app/templates/_helpers.tpl
+++ b/helm/cert-manager-app/templates/_helpers.tpl
@@ -49,7 +49,7 @@ giantswarm.io/service-type: "managed"
 
 {{- define "certManager.CRDInstallAnnotations" -}}
 "helm.sh/hook": "pre-install,pre-upgrade"
-"helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+"helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
 {{- end -}}
 
 {{- define "certManager.CRDLabels" -}}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13403

Recommended solution for `already exists` error in [helm docs](https://v2.helm.sh/docs/charts_hooks/#automatically-delete-hook-from-previous-release).