### PR TITLE
Add values.schema.json to cert manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- Added values.schema.json for validation of default values
+
 ## [2.3.0] - 2020-10-02
 
 ### Changed

--- a/helm/cert-manager-app/Chart.yaml
+++ b/helm/cert-manager-app/Chart.yaml
@@ -7,4 +7,6 @@ icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.p
 name: cert-manager-app
 sources:
 - https://github.com/jetstack/cert-manager
+annotations:
+    application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/cert-manager-app/v[[ .Version ]]/helm/cert-manager-app/values.schema.json  
 version: [[ .Version ]]

--- a/helm/cert-manager-app/Chart.yaml
+++ b/helm/cert-manager-app/Chart.yaml
@@ -8,5 +8,5 @@ name: cert-manager-app
 sources:
 - https://github.com/jetstack/cert-manager
 annotations:
-    application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/cert-manager-app/v[[ .Version ]]/helm/cert-manager-app/values.schema.json  
+    application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/cert-manager-app/v[[ .Version ]]/helm/cert-manager-app/values.schema.json
 version: [[ .Version ]]

--- a/helm/cert-manager-app/values.schema.json
+++ b/helm/cert-manager-app/values.schema.json
@@ -1,0 +1,220 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "cainjector": {
+            "type": "object",
+            "properties": {
+                "extraArgs": {
+                    "type": "array"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "logLevel": {
+                    "type": "null"
+                },
+                "replicas": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "controller": {
+            "type": "object",
+            "properties": {
+                "aws": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "defaultIssuer": {
+                    "type": "object",
+                    "properties": {
+                        "group": {
+                            "type": "string"
+                        },
+                        "kind": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "extraArgs": {
+                    "type": "array"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "logLevel": {
+                    "type": "null"
+                },
+                "replicas": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "crds": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "install": {
+                    "type": "boolean"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "giantSwarmClusterIssuer": {
+                    "type": "object",
+                    "properties": {
+                        "install": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "groupID": {
+                            "type": "integer"
+                        },
+                        "userID": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "prometheus": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "webhook": {
+            "type": "object",
+            "properties": {
+                "extraArgs": {
+                    "type": "array"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "logLevel": {
+                    "type": "null"
+                },
+                "replicas": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "securePort": {
+                    "type": "integer"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/136

This PR adds `values.schema.json` generated from the current values.yaml using https://github.com/karuppiah7890/helm-schema-gen

It is a good starting point and can be further refined by those that know more about the specifics of the values. (For example if we know that `provider` must be aws|azure|kvm, we can actually enforce that as well using the 'enum' property: https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values)

Here's also some more general info: https://www.arthurkoziel.com/validate-helm-chart-values-with-json-schemas/

I want but couldn't validated this generated schema against the app. Wanted to try check at least in `gorilla` and `asgard` 

Got these errors in `gorilla`

```
➜  kubectl-gs git:(app-validate) ./kubectl-gs validate apps -n rfjh2 cert-manager -f=/Users/chiaracokieng/Documents/GitHub/cert-manager-app/helm/cert-manager-app/values.schema.json -o report
Error: Apps.application.giantswarm.io "cert-manager" not found
➜  kubectl-gs git:(app-validate) ./kubectl-gs validate apps -n rfjh2 cert-manager-app -f=/Users/chiaracokieng/Documents/GitHub/cert-manager-app/helm/cert-manager-app/values.schema.json -o report
Error: Apps.application.giantswarm.io "cert-manager-app" not found
```

Maybe I'm using the wrong app name? @oponder @glitchcrab 

I used the currently in progress `kubectl-gs validate apps` command to help with the verifying current values : https://github.com/giantswarm/kubectl-gs/pull/196

Here's also a slack thread with a video about how that command works: https://gigantic.slack.com/archives/CRZN9GLJW/p1603092812002400