### PR TITLE
Update Chart.yaml to 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Made cert-manager version configurable.
+
+### Fixed
+
+- Updated app version in Chart.yaml metadata to `v1.0.3`.
+
 ## [2.3.1] - 2020-10-29
 
 ### Changed

--- a/helm/cert-manager-app/Chart.yaml
+++ b/helm/cert-manager-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.0.2
+appVersion: 1.0.3
 description: A Helm chart for cert-manager
 engine: gotpl
 home: https://github.com/giantswarm/cert-manager-app

--- a/helm/cert-manager-app/templates/cainjector-deployment.yaml
+++ b/helm/cert-manager-app/templates/cainjector-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         runAsGroup: {{ .Values.global.securityContext.groupID }}
       containers:
         - name: cainjector
-          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-cainjector:v1.0.3"
+          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-cainjector:{{ .Values.global.image.version }}"
           imagePullPolicy: {{ .Values.cainjector.image.pullPolicy }}
           args:
           - --v={{ .Values.cainjector.logLevel | default 2 }}

--- a/helm/cert-manager-app/templates/controller-deployment.yaml
+++ b/helm/cert-manager-app/templates/controller-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         runAsGroup: {{ .Values.global.securityContext.groupID }}
       containers:
         - name: cert-manager
-          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-controller:v1.0.3"
+          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-controller:{{ .Values.global.image.version }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)

--- a/helm/cert-manager-app/templates/webhook-deployment.yaml
+++ b/helm/cert-manager-app/templates/webhook-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: {{ template "certManager.name.webhook" . }}
       containers:
         - name: webhook
-          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-webhook:v1.0.3"
+          image: "{{ .Values.global.image.registry }}/giantswarm/cert-manager-webhook:{{ .Values.global.image.version }}"
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
           args:
           - --v={{ .Values.webhook.logLevel | default 2 }}

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -150,7 +150,7 @@ global:
     # global.image.version
     # cert-manager version.
     # IMPORTANT: this should not be changed.
-    # NOTE: When upgrading, make sure to reflect the change in Chart.yaml metdata too.
+    # NOTE: When upgrading, make sure to reflect the change in Chart.yaml metadata too.
     version: v1.0.3
 
   # global.name

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -147,6 +147,12 @@ global:
     # IMPORTANT: this should not be changed.
     registry: quay.io
 
+    # global.image.version
+    # cert-manager version.
+    # IMPORTANT: this should not be changed.
+    # NOTE: When upgrading, make sure to reflect the change in Chart.yaml metdata too.
+    version: v1.0.3
+
   # global.name
   # Set the name stub used in all resources. If not set, the Helm release
   # name will be used.


### PR DESCRIPTION
While handling an incident https://gigantic.slack.com/archives/C03CPNRTS/p1604067749119200 I've noticed that cert-manager-app v2.3.1 based helm release, that got installed on asgard CP, has wrong cert-manager app version metadata.

It was missed in https://github.com/giantswarm/cert-manager-app/pull/86 to update Chart.yaml metadata about app version used.

This PR fixes the issue.

<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/organizational-structure/teams/halo/app-testing/cert-manager/
-->

<!--
@app-squad-cert-manager will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- adds/changes/removes etc

### Testing

#### Optional app

- [ ] fresh install
- [ ] upgrade from previous version

#### Pre-installed app

- [ ] fresh install during cluster creation
- [ ] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Use helloworld app to obtain a certificate, then upgrade the app
and ensure the CRs are still reconciled after the upgrade.
-->

- [ ] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

