### PR TITLE
update cert-manager to v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Added values.schema.json for validation of default values
 - Made cert-manager version configurable.
 
+### Changed
+
+- Updated `cert-manager` to v1.0.4. ([#94](https://github.com/giantswarm/cert-manager-app/pull/94))
+
 ### Fixed
 
 - Updated app version in Chart.yaml metadata to `v1.0.3`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Added values.schema.json for validation of default values
-- Made cert-manager version configurable.
+- Added values.schema.json for validation of default values. ([#90](https://github.com/giantswarm/cert-manager-app/pull/90))
+- Made cert-manager version configurable. ([#91](https://github.com/giantswarm/cert-manager-app/pull/91))
 
 ### Changed
 
-- Updated `cert-manager` to v1.0.4. ([#94](https://github.com/giantswarm/cert-manager-app/pull/94))
+- Updated `cert-manager` to v1.0.4. ([#95](https://github.com/giantswarm/cert-manager-app/pull/95))
 
 ### Fixed
 
-- Updated app version in Chart.yaml metadata to `v1.0.3`.
+- Updated app version in Chart.yaml metadata to `v1.0.3`. ([#91](https://github.com/giantswarm/cert-manager-app/pull/91))
 
 ## [2.3.1] - 2020-10-29
 
@@ -38,13 +38,13 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Fix `hook-delete-policy` to delete hook resources to make upgrades reliable.
+- Fix `hook-delete-policy` to delete hook resources to make upgrades reliable. ([#76](https://github.com/giantswarm/cert-manager-app/pull/76))
 
 ## [2.2.4] - 2020-09-29
 
 ### Added
 
-- Add an optional Kiam annotation in case that Route53 wants to be used.
+- Add an optional Kiam annotation in case that Route53 wants to be used. ([#71](https://github.com/giantswarm/cert-manager-app/pull/71))
 
 ## [2.1.4] - 2020-09-07
 

--- a/helm/cert-manager-app/Chart.yaml
+++ b/helm/cert-manager-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.0.3
+appVersion: 1.0.4
 description: A Helm chart for cert-manager
 engine: gotpl
 home: https://github.com/giantswarm/cert-manager-app

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -151,7 +151,7 @@ global:
     # cert-manager version.
     # IMPORTANT: this should not be changed.
     # NOTE: When upgrading, make sure to reflect the change in Chart.yaml metadata too.
-    version: v1.0.3
+    version: v1.0.4
 
   # global.name
   # Set the name stub used in all resources. If not set, the Helm release


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/organizational-structure/teams/halo/app-testing/cert-manager/
-->

<!--
@app-squad-cert-manager will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- updates cert-manager to 1.0.4

This is a patch version which includes bug fixes only - the full set of tests aren't required.

### Testing

- [x] check the app starts and runs.

### Checklist

- [x] Update changelog in CHANGELOG.md.

