### PR TITLE
correct resource name in migration script

### DIFF
--- a/files/migrate-v090-to-v200.sh
+++ b/files/migrate-v090-to-v200.sh
@@ -279,10 +279,10 @@ parse_args () {
   fi
 
   if [[ ${UPDATE_INGRESSES} -eq 1 ]]; then
-    update_resources ingresses
+    update_resources ingress
   fi
   if [[ ${UPDATE_SECRETS} -eq 1 ]]; then
-    update_resources secrets
+    update_resources secret
   fi
 }
 


### PR DESCRIPTION
this pr corrects a daft mistake in the migration script which would cause it not to run
