### PR TITLE
test: don't delete failed hooks

### DIFF
--- a/helm/cert-manager-app/templates/_helpers.tpl
+++ b/helm/cert-manager-app/templates/_helpers.tpl
@@ -38,7 +38,7 @@ giantswarm.io/service-type: "managed"
 
 {{- define "certManager.CRDInstallAnnotations" -}}
 "helm.sh/hook": "pre-install,pre-upgrade"
-"helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+"helm.sh/hook-delete-policy": "hook-succeeded"
 {{- end -}}
 
 {{- define "certManager.CRDLabels" -}}


### PR DESCRIPTION
testing PR to keep crd-install hook pods around after a failure
