### PR TITLE
allow CRD install Job to run on masters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,6 @@ workflows:
       - architect/integration-test:
           name: basic-integration-test
           kind-config: "integration/config/kind-config"
-          kind-version: "0.9.0"
           kubernetes-version: "v1.18.8"
           setup-script: "integration/config/setup.sh"
           test-dir: "integration/test/basic"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,10 @@ workflows:
 
       - architect/integration-test:
           name: basic-integration-test
+          kind-config: "integration/config/kind-config"
+          kind-version: "0.9.0"
+          kubernetes-version: "v1.18.8"
+          setup-script: "integration/config/setup.sh"
           test-dir: "integration/test/basic"
           filters:
             # Do not trigger the job on merge to master.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Schedule `crd-install` Job on master nodes. ([#106](https://github.com/giantswarm/cert-manager-app/pull/106))
+- Schedule hook Jobs on master nodes. ([#106](https://github.com/giantswarm/cert-manager-app/pull/106))
 
 ## [2.3.2] - 2020-11-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Schedule `crd-install` Job on master nodes. ([#106](https://github.com/giantswarm/cert-manager-app/pull/106))
+
 ## [2.3.2] - 2020-11-09
 
 ### Added

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/job.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/job.yaml
@@ -11,6 +11,11 @@ metadata:
 spec:
   template:
     spec:
+      nodeSelector:
+        kubernetes.io/role: master
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       serviceAccountName: {{ .Values.name }}
       securityContext:
         runAsUser: {{ .Values.userID }}

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/job.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/job.yaml
@@ -11,8 +11,6 @@ metadata:
 spec:
   template:
     spec:
-      nodeSelector:
-        kubernetes.io/role: master
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule

--- a/helm/cert-manager-app/templates/cainjector-deployment.yaml
+++ b/helm/cert-manager-app/templates/cainjector-deployment.yaml
@@ -18,6 +18,9 @@ spec:
         app.kubernetes.io/component: "cainjector"
         {{- include "certManager.defaultLabels" . | nindent 8 }}
     spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       serviceAccountName: {{ template "certManager.name.cainjector" . }}
       securityContext:
         runAsUser: {{ .Values.global.securityContext.userID }}

--- a/helm/cert-manager-app/templates/controller-deployment.yaml
+++ b/helm/cert-manager-app/templates/controller-deployment.yaml
@@ -27,6 +27,9 @@ spec:
         iam.amazonaws.com/role: {{ .Values.controller.aws.role }}
       {{- end }}
     spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       serviceAccountName: {{ template "certManager.name.controller" . }}
       securityContext:
         runAsUser: {{ .Values.global.securityContext.userID }}

--- a/helm/cert-manager-app/templates/crd-install/crd-job.yaml
+++ b/helm/cert-manager-app/templates/crd-install/crd-job.yaml
@@ -23,6 +23,11 @@ spec:
       securityContext:
         runAsUser: {{ .Values.global.securityContext.userID }}
         runAsGroup: {{ .Values.global.securityContext.groupID }}
+      nodeSelector:
+        kubernetes.io/role: master
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
       - name: kubectl
         image: "{{ .Values.global.image.registry }}/giantswarm/docker-kubectl:latest"

--- a/helm/cert-manager-app/templates/crd-install/crd-job.yaml
+++ b/helm/cert-manager-app/templates/crd-install/crd-job.yaml
@@ -23,8 +23,6 @@ spec:
       securityContext:
         runAsUser: {{ .Values.global.securityContext.userID }}
         runAsGroup: {{ .Values.global.securityContext.groupID }}
-      nodeSelector:
-        kubernetes.io/role: master
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule

--- a/helm/cert-manager-app/templates/webhook-deployment.yaml
+++ b/helm/cert-manager-app/templates/webhook-deployment.yaml
@@ -18,6 +18,9 @@ spec:
         app.kubernetes.io/component: "webhook"
         {{- include "certManager.defaultLabels" . | nindent 8 }}
     spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       serviceAccountName: {{ template "certManager.name.webhook" . }}
       containers:
         - name: webhook

--- a/integration/config/kind-config
+++ b/integration/config/kind-config
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker

--- a/integration/config/setup.sh
+++ b/integration/config/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# label the master so it matches our clusters
+kubectl label no kind-control-plane kubernetes.io/role=master


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/organizational-structure/teams/halo/app-testing/cert-manager/
-->

<!--
@app-squad-cert-manager will be automatically requested for review once
this PR has been submitted.
-->

Towards https://github.com/giantswarm/giantswarm/issues/14281

This PR:

- schedules crd-install job on k8s master nodes.

### Testing

#### Optional app

- [ ] ~~fresh install~~ not relevant
- [ ] ~~upgrade from previous version~~ not relevant

#### Pre-installed app

- [x] fresh install during cluster creation
- [ ] ~~upgrade from previous version in a pre-existing cluster~~ not relevant

#### Other testing

<!--
Use helloworld app to obtain a certificate, then upgrade the app
and ensure the CRs are still reconciled after the upgrade.
-->

- [ ] ~~check reconciliation of existing resources after upgrading~~ not relevant

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

