### PR TITLE
update api group for clusterissuer subchart resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Updated clusterissuer subchart API groups to `cert-manager.io/v1`. ([#124](https://github.com/giantswarm/cert-manager-app/pull/124))
+
 ## [2.4.0] - 2020-12-22
 
 ### Changed

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/misc/clusterissuers.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/misc/clusterissuers.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-giantswarm
@@ -17,7 +17,7 @@ spec:
         ingress:
           class: nginx
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: selfsigned-giantswarm


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/organizational-structure/teams/halo/app-testing/cert-manager/
-->

<!--
@app-squad-cert-manager will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- bumps the api group of the clusterissuer subchart to `v1`

### Testing

- Testing isn't required - this API version has been available in this chart for a while now. This is just housekeeping.

### Checklist

- [x] Update changelog in CHANGELOG.md.

