### PR TITLE
make clusterissuer job backofflimit configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Made backoffLimit for clusterissuer job configurable. ([#125](https://github.com/giantswarm/cert-manager-app/pull/125))
+
 ## [2.4.0] - 2020-12-22
 
 ### Changed

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/job.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/templates/job.yaml
@@ -40,5 +40,5 @@ spec:
         configMap:
           name: {{ .Values.name }}
       restartPolicy: Never
-  backoffLimit: 4
+  backoffLimit: {{ .Values.backoffLimit }}
 {{- end }}

--- a/helm/cert-manager-app/charts/giantswarm-cluster-issuer/values.yaml
+++ b/helm/cert-manager-app/charts/giantswarm-cluster-issuer/values.yaml
@@ -7,6 +7,11 @@ name: cert-manager-giantswarm-clusterissuer
 userID: 1000
 groupID: 1000
 
+# this should be higher than the default (6) in order to ensure
+# that the job is not marked as failed if it runs too soon after
+# the webhook pod has been created.
+backoffLimit: 10
+
 image:
   registry: quay.io
   name: giantswarm/docker-kubectl


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/organizational-structure/teams/halo/app-testing/cert-manager/
-->

<!--
@app-squad-cert-manager will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- makes clusterissuer job backofflimit configurable

### Testing

Testing isn't needed for this PR.

### Checklist

- [x] Update changelog in CHANGELOG.md.

