### PR TITLE
make the crd job backofflimit configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Enabled configuration of certificate Secret deletion when the parent Certificate is deleted. ([#127](https://github.com/giantswarm/cert-manager-app/pull/127))
 
+### Changed
+
+- Made CRD install Job backoffLimit configurable (and increased the default value). ([#129](https://github.com/giantswarm/cert-manager-app/pull/129))
+
 ## [2.4.1] - 2021-01-19
 
 ### Changed

--- a/helm/cert-manager-app/templates/crd-install/crd-job.yaml
+++ b/helm/cert-manager-app/templates/crd-install/crd-job.yaml
@@ -97,5 +97,5 @@ spec:
           - key: orders.yaml
             path: orders.yaml
       restartPolicy: Never
-  backoffLimit: 4
+  backoffLimit: {{ .Values.crds.backoffLimit }}
 {{- end }}

--- a/helm/cert-manager-app/values.schema.json
+++ b/helm/cert-manager-app/values.schema.json
@@ -103,6 +103,9 @@
         "crds": {
             "type": "object",
             "properties": {
+                "backoffLimit": {
+                    "type": "integer"
+                },
                 "image": {
                     "type": "object",
                     "properties": {

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -105,6 +105,11 @@ controller:
 #
 crds:
 
+  # crds.backoffLimit
+  # setting this higher means the CRD creation is less likely to be marked
+  # as failed.
+  backoffLimit: 10
+
   # crds.image
   image:
 


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/organizational-structure/teams/halo/app-testing/cert-manager/
-->

<!--
@app-squad-cert-manager will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- makes the backofflimit for the crd-install job configurable.
- bumps the backofflimit to 10 (up from the default of 6).

### Testing

no testing required (aside from rendering the chart locally).

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

