### PR TITLE
Upgrade controller image to v1.2.0

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -3,6 +3,6 @@ generate-metadata: true
 chart-dir: ./helm/cert-manager-app
 destination: ./build
 # CI overwrites this, check .circleci/config.yaml
-catalog-base-url: https://giantswarm.github.com/default-catalog/
+catalog-base-url: https://giantswarm.github.io/default-catalog/
 
 skip-steps: test_all

--- a/.github/workflows/check_values_schema.yaml
+++ b/.github/workflows/check_values_schema.yaml
@@ -1,0 +1,40 @@
+name: 'check if values schema file has been updated'
+on: pull_request
+
+jobs:
+  check:
+    name: 'check files in PR'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'checkout'
+        uses: actions/checkout@v2
+      - id: files
+        uses: jitterbit/get-changed-files@v1
+      - name: 'show changed files in PR'
+        run: echo "${{ steps.files.outputs.all }}"
+      - name: 'check if values.schema.json was updated'
+        run: |
+          VALUES_FILE_CHANGED="false"
+          SCHEMA_FILE_CHANGED="false"
+
+          if git ls-tree -r ${{ github.ref }} | grep -q "values.schema.json" ; then
+
+            if grep -q "values.yaml" <<< "${{ steps.files.outputs.all }}" ; then
+              VALUES_FILE_CHANGED="true"
+            fi
+
+            if grep -q "values.schema.json" <<< "${{ steps.files.outputs.all }}" ; then
+              SCHEMA_FILE_CHANGED="true"
+            fi
+
+            if [ $VALUES_FILE_CHANGED != $SCHEMA_FILE_CHANGED ]; then
+              echo "FAILED: values.yaml was updated but values.schema.json hasn't been regenerated"
+              echo "Please refer to this doc: https://intranet.giantswarm.io/docs/organizational-structure/teams/halo/app-updates/helm-values-schema/"
+              exit 1
+            fi
+
+            echo "PASSED: values.yaml and values.schema.json both appear to have been updated"
+            exit 0
+          fi
+
+          echo "INFO: values.schema.json not present in this repo - nothing to do"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-
 ### Changed
 
 - Update to upstream `v1.2.0`. ([#151](https://github.com/giantswarm/cert-manager-app/pull/151))
+- cert-manager-app now requires kubernetes version >=1.16.0. ([#151](https://github.com/giantswarm/cert-manager-app/pull/151))
+- Switch rbac rules from `extensions` to `networking.k8s.io` for ingresses. ([#151](https://github.com/giantswarm/cert-manager-app/pull/151))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+
+### Changed
+
+- Update to upstream `v1.2.0`. ([#151](https://github.com/giantswarm/cert-manager-app/pull/151))
+
+### Fixed
+
+- Allow strings and integers in values schema for resources requests and limits. ([#150](https://github.com/giantswarm/cert-manager-app/pull/150))
+
 ## [2.4.4] - 2021-04-06
 
 ### Changed

--- a/helm/cert-manager-app/Chart.yaml
+++ b/helm/cert-manager-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.1.0
+appVersion: 1.2.0
 description: A Helm chart for cert-manager
 engine: gotpl
 home: https://github.com/giantswarm/cert-manager-app
@@ -10,4 +10,4 @@ sources:
 annotations:
     application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/cert-manager-app/v[[ .Version ]]/helm/cert-manager-app/values.schema.json
     application.giantswarm.io/readme: https://raw.githubusercontent.com/giantswarm/cert-manager-app/v[[ .Version ]]/README.md
-version: 2.4.2
+version: 2.5.0

--- a/helm/cert-manager-app/Chart.yaml
+++ b/helm/cert-manager-app/Chart.yaml
@@ -7,7 +7,5 @@ icon: https://s.giantswarm.io/app-icons/1/png/cert-manager-app-light.png
 name: cert-manager-app
 sources:
 - https://github.com/jetstack/cert-manager
-annotations:
-    application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/cert-manager-app/v[[ .Version ]]/helm/cert-manager-app/values.schema.json
-    application.giantswarm.io/readme: https://raw.githubusercontent.com/giantswarm/cert-manager-app/v[[ .Version ]]/README.md
 version: 2.5.0
+kubeVersion: ">=1.16.0-0"

--- a/helm/cert-manager-app/templates/controller-rbac.yaml
+++ b/helm/cert-manager-app/templates/controller-rbac.yaml
@@ -143,7 +143,7 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "services"]
     verbs: ["get", "list", "watch", "create", "delete"]
-  - apiGroups: ["extensions"]
+  - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get", "list", "watch", "create", "delete", "update"]
   # We require the ability to specify a custom hostname when we are creating
@@ -178,13 +178,13 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests", "issuers", "clusterissuers"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
+  - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get", "list", "watch"]
   # We require these rules to support users with the OwnerReferencesPermissionEnforcement
   # admission controller enabled:
   # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-  - apiGroups: ["extensions"]
+  - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses/finalizers"]
     verbs: ["update"]
   - apiGroups: [""]

--- a/helm/cert-manager-app/values.schema.json
+++ b/helm/cert-manager-app/values.schema.json
@@ -29,7 +29,7 @@
                             "type": "object",
                             "properties": {
                                 "cpu": {
-                                    "type": "string"
+                                    "type": ["string", "integer"]
                                 },
                                 "memory": {
                                     "type": "string"
@@ -89,7 +89,7 @@
                             "type": "object",
                             "properties": {
                                 "cpu": {
-                                    "type": "string"
+                                    "type": ["string", "integer"]
                                 },
                                 "memory": {
                                     "type": "string"
@@ -120,11 +120,22 @@
                 "resources": {
                     "type": "object",
                     "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": ["string", "integer"]
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "requests": {
                             "type": "object",
                             "properties": {
                                 "cpu": {
-                                    "type": "string"
+                                    "type": ["string", "integer"]
                                 },
                                 "memory": {
                                     "type": "string"
@@ -214,7 +225,7 @@
                             "type": "object",
                             "properties": {
                                 "cpu": {
-                                    "type": "string"
+                                    "type": ["string", "integer"]
                                 },
                                 "memory": {
                                     "type": "string"

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -164,7 +164,7 @@ global:
     # cert-manager version.
     # IMPORTANT: this should not be changed.
     # NOTE: When upgrading, make sure to reflect the change in Chart.yaml metadata too.
-    version: v1.1.0
+    version: v1.2.0
 
   # global.name
   # Set the name stub used in all resources. If not set, the Helm release


### PR DESCRIPTION
This PR updates the used cert-manager image to 1.2.0.

This chart now requires kubernetes >= 1.16.0 because it switches rbac rules from `extensions` to `networking.k8s.io` for ingresses.

I tested

- on AWS: upgrading + issuing a certificate using ingress
- on Azure: Installing + issueing a certificate using ingress. 
