### PR TITLE
set the DNS server from the installation config when using dns01 solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Set authoritative nameserver to `coredns` when using `dns01` ACME solver. ([#162](https://github.com/giantswarm/cert-manager-app/pull/162))
+
 ## [2.7.0] - 2021-05-05
 
 - Update to upstream `v1.3.1` ([#155](https://github.com/giantswarm/cert-manager-app/pull/155)). This mitigates failed cert-manager-app installations due to CRD conversion issues.

--- a/helm/cert-manager-app/templates/controller-deployment.yaml
+++ b/helm/cert-manager-app/templates/controller-deployment.yaml
@@ -49,7 +49,7 @@ spec:
           {{- end }}
           {{- if eq .Values.Installation.V1.GiantSwarm.CertManager.AcmeSolver "dns01" }}
           - --dns01-recursive-nameservers-only
-          - --dns01-recursive-nameservers="{{ .Values.Installation.V1.GiantSwarm.CertManager.AcmeSolver.DNSServer }}:53"
+          - --dns01-recursive-nameservers="{{ .Values.Installation.V1.GiantSwarm.CertManager.DNSServer }}:53"
           {{- end }}
           {{- if .Values.global.enableCertOwnerRef }}
           - --enable-certificate-owner-ref=true

--- a/helm/cert-manager-app/templates/controller-deployment.yaml
+++ b/helm/cert-manager-app/templates/controller-deployment.yaml
@@ -47,6 +47,10 @@ spec:
           - --default-issuer-kind={{ .Values.controller.defaultIssuer.kind }}
           - --default-issuer-group={{ .Values.controller.defaultIssuer.group }}
           {{- end }}
+          {{- if eq .Values.Installation.V1.GiantSwarm.CertManager.AcmeSolver "dns01" }}
+          - --dns01-recursive-nameservers-only
+          - --dns01-recursive-nameservers="{{ .Values.Installation.V1.GiantSwarm.CertManager.AcmeSolver.DNSServer }}:53"
+          {{- end }}
           {{- if .Values.global.enableCertOwnerRef }}
           - --enable-certificate-owner-ref=true
           {{- end }}

--- a/helm/cert-manager-app/values.schema.json
+++ b/helm/cert-manager-app/values.schema.json
@@ -18,7 +18,7 @@
                                             "type": "string"
                                         },
                                         "DNSServer": {
-                                            "type": "string"
+                                            "type": ["null", "string"]
                                         }
                                     }
                                 }

--- a/helm/cert-manager-app/values.schema.json
+++ b/helm/cert-manager-app/values.schema.json
@@ -16,6 +16,9 @@
                                     "properties": {
                                         "AcmeSolver": {
                                             "type": "string"
+                                        },
+                                        "DNSServer": {
+                                            "type": "string"
                                         }
                                     }
                                 }

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -250,6 +250,12 @@ Installation:
       CertManager:
         AcmeSolver: http01
 
+        # Installation.V1.GiantSwarm.CertManager.DNSServer
+        # IP address of the coredns service. This is required if the installation
+        # is behind a proxy as DNS requests to the domain's authoritative nameservers
+        #  will be blocked.
+        DNSServer: ""
+
     Secret:
       Cloudflare:
         Token: ""


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/organizational-structure/teams/halo/app-testing/cert-manager/
-->

<!--
@app-squad-cert-manager will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- sets the authoritative nameserver for the dns01 solver

### Checklist

- [x] Update changelog in CHANGELOG.md.

