### PR TITLE
migrate app values to config repo layout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@2.9.0
+  architect: giantswarm/architect@4.0.0
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.0.0
+  architect: giantswarm/architect@3.0.0
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Label deployments with `giantswarm.io/monitoring_basic_sli: "true"`. ([#171](https://github.com/giantswarm/cert-manager-app/pull/171))
+- Migrate values file structure to match `config` repo. ([#172](https://github.com/giantswarm/cert-manager-app/pull/172))
 
 ## [2.7.1] - 2021-05-20
 

--- a/helm/cert-manager-app/Chart.yaml
+++ b/helm/cert-manager-app/Chart.yaml
@@ -9,3 +9,6 @@ sources:
 - https://github.com/jetstack/cert-manager
 version: 2.7.0
 kubeVersion: ">=1.16.0-0"
+annotations:
+  application.giantswarm.io/team: "halo"
+  config.giantswarm.io/version: 1.x.x

--- a/helm/cert-manager-app/Chart.yaml
+++ b/helm/cert-manager-app/Chart.yaml
@@ -11,4 +11,4 @@ version: 2.7.0
 kubeVersion: ">=1.16.0-0"
 annotations:
   application.giantswarm.io/team: "halo"
-  config.giantswarm.io/version: "add-cert-manager"
+  config.giantswarm.io/version: 1.x.x

--- a/helm/cert-manager-app/Chart.yaml
+++ b/helm/cert-manager-app/Chart.yaml
@@ -11,4 +11,4 @@ version: 2.7.0
 kubeVersion: ">=1.16.0-0"
 annotations:
   application.giantswarm.io/team: "halo"
-  config.giantswarm.io/version: 1.x.x
+  config.giantswarm.io/version: "add-cert-manager"

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/ci/default-values.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/ci/default-values.yaml
@@ -1,8 +1,0 @@
-Installation:
-  V1:
-    GiantSwarm:
-      CertManager:
-        AcmeSolver: ""
-    Secret:
-      Cloudflare:
-        Token: ""

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/cm.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/cm.yaml
@@ -14,7 +14,7 @@ spec:
       name: letsencrypt-giantswarm
     # Add a single challenge solver, HTTP01 using nginx
     solvers:
-    {{ if eq .Values.Installation.V1.GiantSwarm.CertManager.AcmeSolver "dns01" }}
+    {{ if eq .Values.global.acmeSolver.type "dns01" }}
     - dns01:
         cloudflare:
           email: accounts@giantswarm.io

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/values.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/values.yaml
@@ -21,13 +21,3 @@ resources:
   requests:
     cpu: 50m
     memory: 75Mi
-
-Installation:
-  V1:
-    GiantSwarm:
-      CertManager:
-        AcmeSolver: http01
-
-    Secret:
-      Cloudflare:
-        Token: ""

--- a/helm/cert-manager-app/ci/default-values.yaml
+++ b/helm/cert-manager-app/ci/default-values.yaml
@@ -1,8 +1,0 @@
-Installation:
-  V1:
-    GiantSwarm:
-      CertManager:
-        AcmeSolver: ""
-    Secret:
-      Cloudflare:
-        Token: ""

--- a/helm/cert-manager-app/templates/cloudflare-secret.yaml
+++ b/helm/cert-manager-app/templates/cloudflare-secret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.giantSwarmClusterIssuer.install }}
-{{- if and (eq .Values.Installation.V1.GiantSwarm.CertManager.AcmeSolver "dns01") (ne .Values.Installation.V1.Secret.Cloudflare.Token "") }}
+{{- if and (eq .Values.global.acmeSolver.type "dns01") (ne .Values.global.acmeSolver.secret.cloudflare.token "") }}i
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +7,6 @@ metadata:
   namespace: kube-system
 type: Opaque
 stringData:
-  api-token: {{ .Values.Installation.V1.Secret.Cloudflare.Token }}
+  api-token: {{ .Values.global.acmeSolver.secret.cloudflare.token }}
 {{- end }}
 {{- end }}

--- a/helm/cert-manager-app/templates/cloudflare-secret.yaml
+++ b/helm/cert-manager-app/templates/cloudflare-secret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.giantSwarmClusterIssuer.install }}
-{{- if and (eq .Values.global.acmeSolver.type "dns01") (ne .Values.global.acmeSolver.secret.cloudflare.token "") }}i
+{{- if and (eq .Values.global.acmeSolver.type "dns01") (ne .Values.global.acmeSolver.secret.cloudflare.token "") }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/cert-manager-app/templates/controller-deployment.yaml
+++ b/helm/cert-manager-app/templates/controller-deployment.yaml
@@ -48,9 +48,9 @@ spec:
           - --default-issuer-kind={{ .Values.controller.defaultIssuer.kind }}
           - --default-issuer-group={{ .Values.controller.defaultIssuer.group }}
           {{- end }}
-          {{- if eq .Values.Installation.V1.GiantSwarm.CertManager.AcmeSolver "dns01" }}
+          {{- if eq .Values.global.acmeSolver.type "dns01" }}
           - --dns01-recursive-nameservers-only
-          - --dns01-recursive-nameservers="{{ .Values.Installation.V1.GiantSwarm.CertManager.DNSServer }}:53"
+          - --dns01-recursive-nameservers="{{ .Values.global.acmeSolver.DNSServer }}:53"
           {{- end }}
           {{- if .Values.global.enableCertOwnerRef }}
           - --enable-certificate-owner-ref=true

--- a/helm/cert-manager-app/values.schema.json
+++ b/helm/cert-manager-app/values.schema.json
@@ -2,45 +2,6 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
-        "Installation": {
-            "type": "object",
-            "properties": {
-                "V1": {
-                    "type": "object",
-                    "properties": {
-                        "GiantSwarm": {
-                            "type": "object",
-                            "properties": {
-                                "CertManager": {
-                                    "type": "object",
-                                    "properties": {
-                                        "AcmeSolver": {
-                                            "type": "string"
-                                        },
-                                        "DNSServer": {
-                                            "type": ["null", "string"]
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "Secret": {
-                            "type": "object",
-                            "properties": {
-                                "Cloudflare": {
-                                    "type": "object",
-                                    "properties": {
-                                        "Token": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "cainjector": {
             "type": "object",
             "properties": {
@@ -204,6 +165,30 @@
         "global": {
             "type": "object",
             "properties": {
+                "acmeSolver": {
+                    "type": "object",
+                    "properties": {
+                        "DNSServer": {
+                            "type": ["null", "string"]
+                        },
+                        "secret": {
+                            "type": "object",
+                            "properties": {
+                                "cloudflare": {
+                                    "type": "object",
+                                    "properties": {
+                                        "token": {
+                                            "type": ["null", "string"]
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "enableCertOwnerRef": {
                     "type": "boolean"
                 },

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -143,6 +143,25 @@ crds:
 # Global vars are also available to subcharts.
 global:
 
+  # global.acmeSolver
+  acmeSolver:
+    # global.acmeSolver.DNSServer
+    # IP address of the authorative DNS server to query for challenge records. If the
+    # installation is behind a proxy then this should be the cluster CoreDNS IP.
+    DNSServer: ""
+
+    # global.acmeSolver.secret
+    secret:
+      # global.acmeSolver.secret.cloudflare
+      cloudflare:
+        # global.acmeSolver.secret.cloudflare.token
+        # Cloudflare API token with sufficient scope to create/delete records.
+        token: ""
+
+    # global.acmeSolver.type
+    # ACME solver challenge type (see https://letsencrypt.org/docs/challenge-types/).
+    type: http01
+
   # global.enableCertOwnerRef
   # when this flag is enabled, secrets will be automatically removed when the parent
   # certificate resource is deleted.
@@ -243,19 +262,3 @@ webhook:
 
   serviceAccount:
     automountServiceAccountToken: true
-
-Installation:
-  V1:
-    GiantSwarm:
-      CertManager:
-        AcmeSolver: http01
-
-        # Installation.V1.GiantSwarm.CertManager.DNSServer
-        # IP address of the coredns service. This is required if the installation
-        # is behind a proxy as DNS requests to the domain's authoritative nameservers
-        #  will be blocked.
-        DNSServer: ""
-
-    Secret:
-      Cloudflare:
-        Token: ""


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/organizational-structure/teams/halo/app-testing/cert-manager/
-->

<!--
@app-squad-cert-manager will be automatically requested for review once
this PR has been submitted.
-->

Towards https://github.com/giantswarm/giantswarm/issues/18189

This PR:

- migrates values structure to better fit with giantswarm/config.
- allows successful configuration of the acme solver type.

### Testing

#### Optional app

- [ ] fresh install
- [ ] upgrade from previous version

#### Pre-installed app

- [ ] fresh install during cluster creation
- [ ] upgrade from previous version in a pre-existing cluster

#### Other testing

- [ ] ~~check reconciliation of existing resources after upgrading~~ n/a

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

## Additional

This change allows the chart to continue to be used in WCs because the defaulting remains the same (http01). The only time this will affect customers is if they're using dns01 challenge - this needs to be covered in the release notes.

The main reason for this PR is because the acme solver cannot be configured due to variable scoping issues (see the issue linked above)