### PR TITLE
Add metrics scraping metadata to controller service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add metadata to enable metrics scraping.
+
 ## [2.9.0] - 2021-08-18
 
 ### Changed

--- a/helm/cert-manager-app/templates/controller-service.yaml
+++ b/helm/cert-manager-app/templates/controller-service.yaml
@@ -3,8 +3,12 @@ kind: Service
 metadata:
   name: {{ template "certManager.name.controller" . }}
   namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    giantswarm.io/monitoring-path: "/metrics"
+    giantswarm.io/monitoring-port: "9402"
   labels:
     app.kubernetes.io/component: "controller"
+    giantswarm.io/monitoring: "true"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
 spec:
   type: ClusterIP


### PR DESCRIPTION
This PR adds labels and annotations required for metric scraping. 

Towards https://github.com/giantswarm/giantswarm/issues/17817