### PR TITLE
Add giantswarm-managed issuer labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Label default ClusterIssuers with `giantswarm.io/service-type: "managed"` ([#187](https://github.com/giantswarm/cert-manager-app/pull/187)).
+
 ## [2.10.0] - 2021-09-09
 
 ### Changed

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/cm.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/cm.yaml
@@ -3,6 +3,8 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-giantswarm
+  labels:
+    giantswarm.io/service-type: "managed"
 spec:
   acme:
     # Email address used for ACME registration
@@ -31,6 +33,8 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: selfsigned-giantswarm
+  labels:
+    giantswarm.io/service-type: "managed"
 spec:
   selfSigned: {}
 {{- end }}


### PR DESCRIPTION
Adds special label to default installed issuers in preparation for changes in metrics/alerting together with https://github.com/giantswarm/cert-exporter/pull/176