### PR TITLE
change helm.sh/chart label in crds to be shorter

### DIFF
--- a/helm/cert-manager-app/templates/_helpers.tpl
+++ b/helm/cert-manager-app/templates/_helpers.tpl
@@ -46,7 +46,7 @@ app: "{{ template "certManager.name" . }}"
 app.kubernetes.io/name: "{{ template "certManager.name" . }}"
 app.kubernetes.io/instance: "{{ template "certManager.name" . }}"
 app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+helm.sh/chart: "{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}"
 giantswarm.io/service-type: "managed"
 cert-manager.io/disable-validation: "true"
 {{- end -}}


### PR DESCRIPTION
I saw this in the crd-install job

```
Error from server (Invalid): CustomResourceDefinition.apiextensions.k8s.io "certificaterequests.cert-manager.io" is invalid: metadata.labels: Invalid value: "cert-manager-app-2.10.0-33763c8bf729330e5d61cc85a7d2599702cda183": must be no more than 63 characters
Error from server (Invalid): CustomResourceDefinition.apiextensions.k8s.io "certificates.cert-manager.io" is invalid: metadata.labels: Invalid value: "cert-manager-app-2.10.0-33763c8bf729330e5d61cc85a7d2599702cda183": must be no more than 63 characters
Error from server (Invalid): CustomResourceDefinition.apiextensions.k8s.io "challenges.acme.cert-manager.io" is invalid: metadata.labels: Invalid value: "cert-manager-app-2.10.0-33763c8bf729330e5d61cc85a7d2599702cda183": must be no more than 63 characters
Error from server (Invalid): CustomResourceDefinition.apiextensions.k8s.io "clusterissuers.cert-manager.io" is invalid: metadata.labels: Invalid value: "cert-manager-app-2.10.0-33763c8bf729330e5d61cc85a7d2599702cda183": must be no more than 63 characters
Error from server (Invalid): CustomResourceDefinition.apiextensions.k8s.io "issuers.cert-manager.io" is invalid: metadata.labels: Invalid value: "cert-manager-app-2.10.0-33763c8bf729330e5d61cc85a7d2599702cda183": must be no more than 63 characters
Error from server (Invalid): CustomResourceDefinition.apiextensions.k8s.io "orders.acme.cert-manager.io" is invalid: metadata.labels: Invalid value: "cert-manager-app-2.10.0-33763c8bf729330e5d61cc85a7d2599702cda183": must be no more than 63 characters
```

This seems to fix this issue. Tested an upgrade from 2.8.0 to this, IMO not worth mentioning in the changelog