### PR TITLE
fix psp for startupapicheck from upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Label default ClusterIssuers with `giantswarm.io/service-type: "managed"` ([#187](https://github.com/giantswarm/cert-manager-app/pull/187)).
 - Fix startupjob PSP ([#191](https://github.com/giantswarm/cert-manager-app/pull/191))
+- Upgrade to upstream image 1.5.4 ([#191](https://github.com/giantswarm/cert-manager-app/pull/191))
 
 ## [2.10.0] - 2021-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Label default ClusterIssuers with `giantswarm.io/service-type: "managed"` ([#187](https://github.com/giantswarm/cert-manager-app/pull/187)).
+- Fix startupjob PSP ([#191](https://github.com/giantswarm/cert-manager-app/pull/191))
 
 ## [2.10.0] - 2021-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Label default ClusterIssuers with `giantswarm.io/service-type: "managed"` ([#187](https://github.com/giantswarm/cert-manager-app/pull/187)).
 - Fix startupjob PSP ([#191](https://github.com/giantswarm/cert-manager-app/pull/191))
-- Upgrade to upstream image 1.5.4 ([#191](https://github.com/giantswarm/cert-manager-app/pull/191))
+- Upgrade to upstream image `v1.5.4` ([#191](https://github.com/giantswarm/cert-manager-app/pull/191))
 
 ## [2.10.0] - 2021-09-09
 

--- a/helm/cert-manager-app/Chart.yaml
+++ b/helm/cert-manager-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.5.3
+appVersion: 1.5.4
 description: A Helm chart for cert-manager
 engine: gotpl
 home: https://github.com/giantswarm/cert-manager-app
@@ -7,7 +7,7 @@ icon: https://s.giantswarm.io/app-icons/1/png/cert-manager-app-light.png
 name: cert-manager-app
 sources:
 - https://github.com/jetstack/cert-manager
-version: 2.10.0
+version: 2.11.0
 kubeVersion: ">=1.16.0-0"
 annotations:
   application.giantswarm.io/team: "halo"

--- a/helm/cert-manager-app/templates/startupapicheck-psp-clusterrole.yaml
+++ b/helm/cert-manager-app/templates/startupapicheck-psp-clusterrole.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.startupapicheck.enabled -}}
-{{- if .Values.global.podSecurityPolicy.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -20,5 +19,4 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "startupapicheck.fullname" . }}
-{{- end }}
 {{- end }}

--- a/helm/cert-manager-app/templates/startupapicheck-psp-clusterrole.yaml
+++ b/helm/cert-manager-app/templates/startupapicheck-psp-clusterrole.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.global.podSecurityPolicy.enabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "startupapicheck.fullname" . }}-psp
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "startupapicheck"
+    {{- include "certManager.defaultLabels" . | nindent 4 }}
+  {{- if .Values.startupapicheck.rbac.annotations }}
+  annotations:
+    {{ toYaml .Values.startupapicheck.rbac.annotations | nindent 4 }}
+  {{- end }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "startupapicheck.fullname" . }}
+{{- end }}
+{{- end }}

--- a/helm/cert-manager-app/templates/startupapicheck-psp-clusterrolebinding.yaml
+++ b/helm/cert-manager-app/templates/startupapicheck-psp-clusterrolebinding.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.startupapicheck.enabled -}}
-{{- if .Values.global.podSecurityPolicy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -22,5 +21,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "startupapicheck.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end }}
 {{- end }}

--- a/helm/cert-manager-app/templates/startupapicheck-psp-clusterrolebinding.yaml
+++ b/helm/cert-manager-app/templates/startupapicheck-psp-clusterrolebinding.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.global.podSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "startupapicheck.fullname" . }}-psp
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "startupapicheck"
+    {{- include "certManager.defaultLabels" . | nindent 4 }}
+  {{- if .Values.startupapicheck.rbac.annotations }}
+  annotations:
+    {{ toYaml .Values.startupapicheck.rbac.annotations | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "startupapicheck.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "startupapicheck.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/helm/cert-manager-app/templates/startupapicheck-psp.yaml
+++ b/helm/cert-manager-app/templates/startupapicheck-psp.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.global.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "startupapicheck.fullname" . }}
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "startupapicheck"
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    {{- if .Values.global.podSecurityPolicy.useAppArmor }}
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    {{- end }}
+    {{- if .Values.startupapicheck.rbac.annotations }}
+    {{ toYaml .Values.startupapicheck.rbac.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  allowedCapabilities: []  # default set of capabilities are implicitly allowed
+  volumes:
+  - 'projected'
+  - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1000
+      max: 1000
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1000
+      max: 1000
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1000
+      max: 1000
+{{- end -}}
+{{- end -}}

--- a/helm/cert-manager-app/templates/startupapicheck-psp.yaml
+++ b/helm/cert-manager-app/templates/startupapicheck-psp.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.startupapicheck.enabled -}}
-{{- if .Values.global.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -9,14 +8,10 @@ metadata:
     app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "startupapicheck"
-    {{- include "labels" . | nindent 4 }}
+    {{- include "certManager.defaultLabels" . | nindent 4 }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-    {{- if .Values.global.podSecurityPolicy.useAppArmor }}
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
-    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
-    {{- end }}
     {{- if .Values.startupapicheck.rbac.annotations }}
     {{ toYaml .Values.startupapicheck.rbac.annotations | nindent 4 }}
     {{- end }}
@@ -47,5 +42,4 @@ spec:
     ranges:
     - min: 1000
       max: 1000
-{{- end -}}
 {{- end -}}

--- a/helm/cert-manager-app/templates/startupapicheck-rbac.yaml
+++ b/helm/cert-manager-app/templates/startupapicheck-rbac.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.startupapicheck.enabled -}}
-{{- if .Values.global.rbac.create -}}
 # create certificate role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -45,5 +44,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "startupapicheck.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end -}}
 {{- end -}}

--- a/helm/cert-manager-app/templates/startupapicheck-rbac.yaml
+++ b/helm/cert-manager-app/templates/startupapicheck-rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.global.rbac.create -}}
 # create certificate role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -44,4 +45,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "startupapicheck.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end -}}
 {{- end -}}

--- a/helm/cert-manager-app/templates/startupapicheck-serviceaccount.yaml
+++ b/helm/cert-manager-app/templates/startupapicheck-serviceaccount.yaml
@@ -15,6 +15,9 @@ metadata:
     app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "startupapicheck"
-    {{- include "certManager.defaultLabels" . | nindent 4 }}
+    {{- include "labels" . | nindent 4 }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
+{{- end }}
 {{- end -}}
 {{- end -}}

--- a/helm/cert-manager-app/templates/startupapicheck-serviceaccount.yaml
+++ b/helm/cert-manager-app/templates/startupapicheck-serviceaccount.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "startupapicheck"
-    {{- include "labels" . | nindent 4 }}
+    {{- include "certManager.defaultLabels" . | nindent 4 }}
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
 {{- end }}

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -286,7 +286,7 @@ startupapicheck:
   jobAnnotations:
     helm.sh/hook: post-install
     helm.sh/hook-weight: "1"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
   # Optional additional annotations to add to the startupapicheck Pods
   # podAnnotations: {}
@@ -321,10 +321,11 @@ startupapicheck:
     pullPolicy: IfNotPresent
 
   rbac:
+    # annotations for the startup API Check job RBAC and PSP resources
     annotations:
       helm.sh/hook: post-install
       helm.sh/hook-weight: "-5"
-      helm.sh/hook-delete-policy: hook-succeeded
+      helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
   serviceAccount:
     # Specifies whether a service account should be created
@@ -338,7 +339,7 @@ startupapicheck:
     annotations:
       helm.sh/hook: post-install
       helm.sh/hook-weight: "-5"
-      helm.sh/hook-delete-policy: hook-succeeded
+      helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
     # Automount API credentials for a Service Account.
     automountServiceAccountToken: true

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -188,7 +188,7 @@ global:
     # cert-manager version.
     # IMPORTANT: this should not be changed.
     # NOTE: When upgrading, make sure to reflect the change in Chart.yaml metadata too.
-    version: v1.5.3
+    version: v1.5.4
 
   # global.name
   # Set the name stub used in all resources. If not set, the Helm release


### PR DESCRIPTION
Towards giantswarm/giantswarm#19074

<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/organizational-structure/teams/halo/app-testing/cert-manager/
-->

<!--
@app-squad-cert-manager will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- fixes installation issues

### Testing

#### Optional app

- [ ] fresh install
- [ ] upgrade from previous version

#### Pre-installed app

- [x] fresh install during cluster creation
 - tested on `gauss` with `16.0.0-calvix` and `15.3.0-njuettner`
- [ ] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Use helloworld app to obtain a certificate, then upgrade the app
and ensure the CRs are still reconciled after the upgrade.
-->

- [ ] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

