### PR TITLE
Bump ats to enable upgrade tests

### DIFF
--- a/.ats/main.yaml
+++ b/.ats/main.yaml
@@ -1,6 +1,6 @@
 smoke-tests-cluster-type: kind
 
-skip-steps: [functional, upgrade]
+skip-steps: [functional]
 
 upgrade-tests-cluster-type: kind
 upgrade-tests-app-catalog-url: https://giantswarm.github.io/giantswarm-catalog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.8.0
+  architect: giantswarm/architect@4.8.1
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 # app-build-suite artifacts
 build
 test_results_*.xml
-*.kube.config
+*kube.config
+
+__pycache__/
+.pytest_cache/
+
+.vscode/
+.devcontainer/

--- a/tests/ats/Pipfile.lock
+++ b/tests/ats/Pipfile.lock
@@ -64,11 +64,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966",
-                "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==21.2"
+            "version": "==21.3"
         },
         "pluggy": {
             "hashes": [
@@ -80,11 +80,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
-                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.10.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
         },
         "pykube-ng": {
             "hashes": [
@@ -96,11 +96,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
+                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.4.7"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.6"
         },
         "pytest": {
             "hashes": [
@@ -186,7 +186,7 @@
                 "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
                 "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.7"
         },
         "wrapt": {

--- a/tests/ats/test_basic_cluster.py
+++ b/tests/ats/test_basic_cluster.py
@@ -1,5 +1,6 @@
 import logging
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Dict, List
 
 import pykube
@@ -76,8 +77,8 @@ def test_clusterissuer_available(kube_cluster: Cluster):
 
 # Using smoke here, because redeployment takes too much time
 @pytest.mark.smoke
-def test_self_signed_certificates(kube_cluster: Cluster):
+def test_self_signed_certificates(request, kube_cluster: Cluster):
     # Request self signed certificates and check if they get Ready
-    kube_cluster.kubectl("apply", filename="selfsigned.yaml", output_format="")
+    kube_cluster.kubectl("apply", filename=Path(request.fspath.dirname) / "selfsigned.yaml", output_format="")
 
     kube_cluster.kubectl(f"wait certificate test-ca test --for=condition=Ready", timeout="60s", output_format="")


### PR DESCRIPTION
This PR:

Updates CI dependencies architect-orb to 4.8.1 (using app-test-suite 0.2.2) which enables us to execute upgrade tests.