### PR TITLE
Use retagged container image for acme solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Use retagged container image for HTTP01 AcmeSolver ([#212](https://github.com/giantswarm/cert-manager-app/pull/212))
+
 ## [2.12.0] - 2021-12-16
 
 ### Changed

--- a/helm/cert-manager-app/templates/controller-deployment.yaml
+++ b/helm/cert-manager-app/templates/controller-deployment.yaml
@@ -44,6 +44,7 @@ spec:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace={{ .Release.Namespace }}
           - --v={{ .Values.controller.logLevel | default 2 }}
+          - --acme-http01-solver-image={{ .Values.global.image.registry }}/giantswarm/cert-manager-acmesolver:{{ .Values.global.image.version }}
           {{- if or (.Values.controller.defaultIssuer) (.Values.global.giantSwarmClusterIssuer.install) }}
           - --default-issuer-name={{ .Values.controller.defaultIssuer.name }}
           - --default-issuer-kind={{ .Values.controller.defaultIssuer.kind }}


### PR DESCRIPTION
This PR: (Towards https://github.com/giantswarm/giantswarm/issues/20279)

- Changes the deployment to use retagged container image for acme solver

### Testing

- lets encrypt certificate could be obtained in test on aws cluster

### Checklist

- [x] Update changelog in CHANGELOG.md.

