### PR TITLE
Use 1.23.3 kubectl container in crd install job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Use retagged container image for HTTP01 AcmeSolver ([#212](https://github.com/giantswarm/cert-manager-app/pull/212))
+- Pin kubectl to 1.23.3 in crd-install and clusterissuer-install jobs ([#216](https://github.com/giantswarm/cert-manager-app/pull/216))
 
 ## [2.12.0] - 2021-12-16
 

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/values.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/values.yaml
@@ -15,7 +15,7 @@ backoffLimit: 10
 image:
   registry: quay.io
   name: giantswarm/docker-kubectl
-  tag: latest
+  tag: 1.23.3
 
 resources:
   requests:

--- a/helm/cert-manager-app/templates/crd-install/crd-job.yaml
+++ b/helm/cert-manager-app/templates/crd-install/crd-job.yaml
@@ -28,7 +28,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kubectl
-        image: "{{ .Values.global.image.registry }}/giantswarm/docker-kubectl:latest"
+        image: "{{ .Values.global.image.registry }}/giantswarm/docker-kubectl:1.23.3"
         command:
         - sh
         - -c


### PR DESCRIPTION
This PR

Pins the used kubectl container image version from `latest` to `1.23.3` to prevent a situation when docker.io is used as registry where `latest` is very old

### Checklist

- [x] Update changelog in CHANGELOG.md.

