### PR TITLE
add team to default labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Use retagged container image for HTTP01 AcmeSolver ([#212](https://github.com/giantswarm/cert-manager-app/pull/212))
 - Pin kubectl to 1.23.3 in crd-install and clusterissuer-install jobs ([#216](https://github.com/giantswarm/cert-manager-app/pull/216))
+- Add `application.giantswarm.io/team` to default labels ([#224](https://github.com/giantswarm/cert-manager-app/pull/224)).
 
 ## [2.12.0] - 2021-12-16
 

--- a/helm/cert-manager-app/templates/_helpers.tpl
+++ b/helm/cert-manager-app/templates/_helpers.tpl
@@ -34,6 +34,7 @@ app.kubernetes.io/instance: "{{ template "certManager.name" . }}"
 app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 helm.sh/chart: "{{ template "certManager.chart" . }}"
 giantswarm.io/service-type: "managed"
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 {{- end -}}
 
 {{- define "certManager.CRDInstallAnnotations" -}}


### PR DESCRIPTION
This PR changes the default labels to include the `application.giantswarm.io/team` label with value from the Chart.yaml annotation with the same name. 

Towards https://github.com/giantswarm/giantswarm/issues/20482