### PR TITLE
Upgrade cert-manager to 1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade to upstream image [`v1.7.3`](https://github.com/jetstack/cert-manager/releases/tag/v1.7.3) which increases some hard-coded timeouts for certain ACME issuers (ZeroSSL and Sectigo) ([#243](https://github.com/giantswarm/cert-manager-app/pull/243))
+- Update kubectl container version to `1.24.2` ([#243](https://github.com/giantswarm/cert-manager-app/pull/243))
+
 ## [2.14.0] - 2022-06-20
 
 ### Fixed

--- a/helm/cert-manager-app/Chart.yaml
+++ b/helm/cert-manager-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.7.2
+appVersion: 1.7.3
 description: Simplifies the process of obtaining, renewing and using certificates
 home: https://github.com/giantswarm/cert-manager-app
 icon: https://s.giantswarm.io/app-icons/cert-manager/1/light.svg

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/values.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/values.yaml
@@ -15,7 +15,7 @@ backoffLimit: 10
 image:
   registry: quay.io
   name: giantswarm/docker-kubectl
-  tag: 1.24.1
+  tag: 1.24.2
 
 resources:
   requests:

--- a/helm/cert-manager-app/templates/crd-install/crd-job.yaml
+++ b/helm/cert-manager-app/templates/crd-install/crd-job.yaml
@@ -28,7 +28,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kubectl
-        image: "{{ .Values.global.image.registry }}/giantswarm/docker-kubectl:1.24.1"
+        image: "{{ .Values.global.image.registry }}/giantswarm/docker-kubectl:1.24.2"
         imagePullPolicy: Always
         command:
         - sh

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -188,7 +188,7 @@ global:
     # cert-manager version.
     # IMPORTANT: this should not be changed.
     # NOTE: When upgrading, make sure to reflect the change in Chart.yaml metadata too.
-    version: v1.7.2
+    version: v1.7.3
 
   # global.name
   # Set the name stub used in all resources. If not set, the Helm release


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/organizational-structure/teams/halo/app-testing/cert-manager/
-->

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- Updates the cert-manager versions to [1.7.3](https://github.com/cert-manager/cert-manager/releases/tag/v1.7.3)
- Updates the kubectl version to 1.24.2

### Testing

#### Optional app

- [ ] fresh install
- [ ] upgrade from previous version

#### Pre-installed app

- [ ] fresh install during cluster creation
- [ ] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install nginx-ingress-controller-app and hello-world-app to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [ ] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

