### PR TITLE
Run cmctl upgrade migrate-api-version in CRD install job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Automatically try to execute `cmctl upgrade migrate-api-version` in crd install job to upgrade stored apiversions ([#245](https://github.com/giantswarm/cert-manager-app/pull/245))
+
 ## [2.15.0] - 2022-06-24
 
 ### Changed

--- a/helm/cert-manager-app/templates/crd-install/crd-job.yaml
+++ b/helm/cert-manager-app/templates/crd-install/crd-job.yaml
@@ -39,15 +39,9 @@ spec:
           # piping stderr to stdout means kubectl's errors are surfaced
           # in the pod's logs.
 
-          cd $HOME
-          set +e
-          kubectl get crd certificates.cert-manager.io
-          crd_exist=$?
-          set -e
-
-          if [ $crd_exist -eq 0 ]; then
+          if kubectl get crd certificates.cert-manager.io > /dev/null ; then
             # execute cmctl upgrade migrate-api-version
-            ./cmctl upgrade migrate-api-version
+            cmctl upgrade migrate-api-version
           fi
 
           # patch ownership of fields in crds first

--- a/helm/cert-manager-app/templates/crd-install/crd-job.yaml
+++ b/helm/cert-manager-app/templates/crd-install/crd-job.yaml
@@ -39,12 +39,21 @@ spec:
           # piping stderr to stdout means kubectl's errors are surfaced
           # in the pod's logs.
 
-          dl_url="https://github.com/cert-manager/cert-manager/releases/download/v{{ .Values.global.image.version }}/cmctl-linux-amd64.tar.gz"
-          echo "Fetching cmctl from $dl_url"
-          wget -S -O - "$dl_url" | tar xvz cmctl
+          cd $HOME
+          set +e
+          kubectl get crd certificates.cert-manager.io
+          crd_exist=$?
+          set -e
 
-          # execute cmctl upgrade migrate-api-version
-          ./cmctl upgrade migrate-api-version
+          if [ $crd_exist -eq 0 ]; then
+            # fetch cmctl
+            dl_url="https://github.com/cert-manager/cert-manager/releases/download/{{ .Values.global.image.version }}/cmctl-linux-amd64.tar.gz"
+            echo "Fetching cmctl from $dl_url"
+            wget -S -O - "$dl_url" | tar xvz cmctl
+
+            # execute cmctl upgrade migrate-api-version
+            ./cmctl upgrade migrate-api-version
+          fi
 
           # patch ownership of fields in crds first
           for crd_name in certificaterequests.cert-manager.io certificates.cert-manager.io challenges.acme.cert-manager.io clusterissuers.cert-manager.io issuers.cert-manager.io orders.acme.cert-manager.io; do

--- a/helm/cert-manager-app/templates/crd-install/crd-job.yaml
+++ b/helm/cert-manager-app/templates/crd-install/crd-job.yaml
@@ -28,7 +28,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kubectl
-        image: "{{ .Values.global.image.registry }}/giantswarm/docker-kubectl:1.24.2"
+        image: "{{ .Values.global.image.registry }}/giantswarm/docker-kubectl:1.24.2-gs-issue-22730"
         imagePullPolicy: Always
         command:
         - sh
@@ -46,11 +46,6 @@ spec:
           set -e
 
           if [ $crd_exist -eq 0 ]; then
-            # fetch cmctl
-            dl_url="https://github.com/cert-manager/cert-manager/releases/download/{{ .Values.global.image.version }}/cmctl-linux-amd64.tar.gz"
-            echo "Fetching cmctl from $dl_url"
-            wget -S -O - "$dl_url" | tar xvz cmctl
-
             # execute cmctl upgrade migrate-api-version
             ./cmctl upgrade migrate-api-version
           fi

--- a/helm/cert-manager-app/templates/crd-install/crd-job.yaml
+++ b/helm/cert-manager-app/templates/crd-install/crd-job.yaml
@@ -39,6 +39,13 @@ spec:
           # piping stderr to stdout means kubectl's errors are surfaced
           # in the pod's logs.
 
+          dl_url="https://github.com/cert-manager/cert-manager/releases/download/v{{ .Values.global.image.version }}/cmctl-linux-amd64.tar.gz"
+          echo "Fetching cmctl from $dl_url"
+          wget -S -O - "$dl_url" | tar xvz cmctl
+
+          # execute cmctl upgrade migrate-api-version
+          ./cmctl upgrade migrate-api-version
+
           # patch ownership of fields in crds first
           for crd_name in certificaterequests.cert-manager.io certificates.cert-manager.io challenges.acme.cert-manager.io clusterissuers.cert-manager.io issuers.cert-manager.io orders.acme.cert-manager.io; do
             set +e


### PR DESCRIPTION
This PR:

- adds execution of `cmctl upgrade migrate-api-version` to update stored apiversions on the target cluster. This is sometimes required because etcd/api stores CRs in a specific apiversion and cert-manager 1.7 has removed support for alpha and beta version of its CRDs

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

