### PR TITLE
Upgrade to cert-manager v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+Before you upgrade to this release, make sure to read the [Upgrading from v1.7 to v1.8](https://cert-manager.io/docs/installation/upgrading/upgrading-1.7-1.8/) document.
+
+### Changed
+
+- Upgrade to upstream image [`v1.8.2`](https://github.com/jetstack/cert-manager/releases/tag/v1.8.2). ([#259](https://github.com/giantswarm/cert-manager-app/pull/259))
+
 ## [2.15.3] - 2022-08-22
 
 ### Added

--- a/helm/cert-manager-app/Chart.yaml
+++ b/helm/cert-manager-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.7.3
+appVersion: 1.8.2
 description: Simplifies the process of obtaining, renewing and using certificates
 home: https://github.com/giantswarm/cert-manager-app
 icon: https://s.giantswarm.io/app-icons/cert-manager/1/light.svg

--- a/helm/cert-manager-app/files/certificaterequests.yaml
+++ b/helm/cert-manager-app/files/certificaterequests.yaml
@@ -185,6 +185,9 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`, `InvalidRequest`, `Approved`, `Denied`).
                         type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
                 failureTime:
                   description: FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.
                   type: string

--- a/helm/cert-manager-app/files/certificates.yaml
+++ b/helm/cert-manager-app/files/certificates.yaml
@@ -65,7 +65,7 @@ spec:
                 - secretName
               properties:
                 additionalOutputFormats:
-                  description: AdditionalOutputFormats defines extra output formats of the private key and signed certificate chain to be written to this Certificate's target Secret. This is an Alpha Feature and is only enabled with the `--feature-gates=AdditionalCertificateOutputFormats=true` option.
+                  description: AdditionalOutputFormats defines extra output formats of the private key and signed certificate chain to be written to this Certificate's target Secret. This is an Alpha Feature and is only enabled with the `--feature-gates=AdditionalCertificateOutputFormats=true` option on both the controller and webhook components.
                   type: array
                   items:
                     description: CertificateAdditionalOutputFormat defines an additional output format of a Certificate resource. These contain supplementary data formats of the signed certificate chain and paired private key.
@@ -189,6 +189,9 @@ spec:
                     rotationPolicy:
                       description: RotationPolicy controls how private keys should be regenerated when a re-issuance is being processed. If set to Never, a private key will only be generated if one does not already exist in the target `spec.secretName`. If one does exists but it does not have the correct algorithm or size, a warning will be raised to await user intervention. If set to Always, a private key matching the specified requirements will be generated whenever a re-issuance occurs. Default is 'Never' for backward compatibility.
                       type: string
+                      enum:
+                        - Never
+                        - Always
                     size:
                       description: Size is the key bit size of the corresponding private key for this certificate. If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`, and will default to `2048` if not specified. If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`, and will default to `256` if not specified. If `algorithm` is set to `Ed25519`, Size is ignored. No other values are allowed.
                       type: integer
@@ -331,6 +334,12 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`, `Issuing`).
                         type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                failedIssuanceAttempts:
+                  description: The number of continuous failed issuance attempts up till now. This field gets removed (if set) on a successful issuance and gets set to 1 if unset and an issuance has failed. If an issuance has failed, the delay till the next issuance will be calculated using formula time.Hour * 2 ^ (failedIssuanceAttempts - 1).
+                  type: integer
                 lastFailureTime:
                   description: LastFailureTime is the time as recorded by the Certificate controller of the most recent failure to complete a CertificateRequest for this Certificate resource. If set, cert-manager will not re-request another Certificate until 1 hour has elapsed from this time.
                   type: string

--- a/helm/cert-manager-app/files/challenges.yaml
+++ b/helm/cert-manager-app/files/challenges.yaml
@@ -374,10 +374,49 @@ spec:
                           type: object
                           properties:
                             labels:
-                              description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                              description: Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.
                               type: object
                               additionalProperties:
                                 type: string
+                            parentRefs:
+                              description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
+                              type: array
+                              items:
+                                description: "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object."
+                                type: object
+                                required:
+                                  - name
+                                properties:
+                                  group:
+                                    description: "Group is the group of the referent. \n Support: Core"
+                                    type: string
+                                    default: gateway.networking.k8s.io
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  kind:
+                                    description: "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)"
+                                    type: string
+                                    default: Gateway
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                  name:
+                                    description: "Name is the name of the referent. \n Support: Core"
+                                    type: string
+                                    maxLength: 253
+                                    minLength: 1
+                                  namespace:
+                                    description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                                    type: string
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  sectionName:
+                                    description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
+                                    type: string
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             serviceType:
                               description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                               type: string

--- a/helm/cert-manager-app/files/clusterissuers.yaml
+++ b/helm/cert-manager-app/files/clusterissuers.yaml
@@ -409,10 +409,49 @@ spec:
                                 type: object
                                 properties:
                                   labels:
-                                    description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                                    description: Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.
                                     type: object
                                     additionalProperties:
                                       type: string
+                                  parentRefs:
+                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
+                                    type: array
+                                    items:
+                                      description: "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object."
+                                      type: object
+                                      required:
+                                        - name
+                                      properties:
+                                        group:
+                                          description: "Group is the group of the referent. \n Support: Core"
+                                          type: string
+                                          default: gateway.networking.k8s.io
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        kind:
+                                          description: "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)"
+                                          type: string
+                                          default: Gateway
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                        name:
+                                          description: "Name is the name of the referent. \n Support: Core"
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                        namespace:
+                                          description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                                          type: string
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        sectionName:
+                                          description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                   serviceType:
                                     description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
@@ -1200,6 +1239,8 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`).
                         type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
       served: true
       storage: true
----

--- a/helm/cert-manager-app/files/issuers.yaml
+++ b/helm/cert-manager-app/files/issuers.yaml
@@ -409,10 +409,49 @@ spec:
                                 type: object
                                 properties:
                                   labels:
-                                    description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                                    description: Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.
                                     type: object
                                     additionalProperties:
                                       type: string
+                                  parentRefs:
+                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
+                                    type: array
+                                    items:
+                                      description: "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object."
+                                      type: object
+                                      required:
+                                        - name
+                                      properties:
+                                        group:
+                                          description: "Group is the group of the referent. \n Support: Core"
+                                          type: string
+                                          default: gateway.networking.k8s.io
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        kind:
+                                          description: "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)"
+                                          type: string
+                                          default: Gateway
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                        name:
+                                          description: "Name is the name of the referent. \n Support: Core"
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                        namespace:
+                                          description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                                          type: string
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        sectionName:
+                                          description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                   serviceType:
                                     description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
@@ -1200,5 +1239,8 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`).
                         type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
       served: true
       storage: true

--- a/helm/cert-manager-app/templates/cainjector-rbac.yaml
+++ b/helm/cert-manager-app/templates/cainjector-rbac.yaml
@@ -24,9 +24,6 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["auditregistration.k8s.io"]
-    resources: ["auditsinks"]
-    verbs: ["get", "list", "watch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -59,14 +56,6 @@ rules:
   #   see cmd/cainjector/start.go#L113
   # cert-manager-cainjector-leader-election-core is used by the SecretBased injector controller
   #   see cmd/cainjector/start.go#L137
-  # See also: https://github.com/kubernetes-sigs/controller-runtime/pull/1144#discussion_r480173688
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"]
-    verbs: ["get", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["create"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"]

--- a/helm/cert-manager-app/templates/cainjector-serviceaccount.yaml
+++ b/helm/cert-manager-app/templates/cainjector-serviceaccount.yaml
@@ -7,3 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/component: "cainjector"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
+    {{- with .Values.cainjector.serviceAccount.labels }}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}

--- a/helm/cert-manager-app/templates/controller-deployment.yaml
+++ b/helm/cert-manager-app/templates/controller-deployment.yaml
@@ -64,6 +64,7 @@ spec:
             readOnlyRootFilesystem: true
           ports:
           - containerPort: 9402
+            name: http-metrics
             protocol: TCP
           env:
           - name: POD_NAMESPACE

--- a/helm/cert-manager-app/templates/controller-rbac.yaml
+++ b/helm/cert-manager-app/templates/controller-rbac.yaml
@@ -1,6 +1,47 @@
-## CLUSTER ROLES
+## ROLES
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "certManager.name.controller" . }}:leaderelection
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/component: "controller"
+    {{- include "certManager.defaultLabels" . | nindent 4 }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: ["cert-manager-controller"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
 
+## ROLE BINDINGS
 ---
+
+# grant cert-manager permission to manage the leaderelection configmap in the
+# leader election namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "certManager.name.controller" . }}:leaderelection
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/component: "controller"
+    {{- include "certManager.defaultLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "certManager.name.controller" . }}:leaderelection
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ template "certManager.name.controller" . }}
+    namespace: {{ .Release.Namespace | quote }}
+
+## CLUSTER ROLES
+---
+
 # Issuer controller role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -12,7 +53,7 @@ metadata:
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers"]
     verbs: ["get", "list", "watch"]
@@ -22,7 +63,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+
 ---
+
 # ClusterIssuer controller role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -34,7 +77,7 @@ metadata:
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers"]
     verbs: ["get", "list", "watch"]
@@ -44,7 +87,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+
 ---
+
 # Certificates controller role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -56,7 +101,7 @@ metadata:
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests", "clusterissuers", "issuers"]
     verbs: ["get", "list", "watch"]
@@ -75,7 +120,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+
 ---
+
 # Orders controller role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -87,7 +134,7 @@ metadata:
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "challenges"]
     verbs: ["get", "list", "watch"]
@@ -109,7 +156,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+
 ---
+
 # Challenges controller role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -122,7 +171,7 @@ rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["challenges", "challenges/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   # Used to watch challenge resources
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["challenges"]
@@ -146,7 +195,7 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get", "list", "watch", "create", "delete", "update"]
-  - apiGroups: [ "networking.x-k8s.io" ]
+  - apiGroups: [ "gateway.networking.k8s.io" ]
     resources: [ "httproutes" ]
     verbs: ["get", "list", "watch", "create", "delete", "update"]
   # We require the ability to specify a custom hostname when we are creating
@@ -165,7 +214,9 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
+
 ---
+
 # ingress-shim controller role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -190,25 +241,137 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses/finalizers"]
     verbs: ["update"]
-  - apiGroups: ["networking.x-k8s.io"]
+  - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways", "httproutes"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["networking.x-k8s.io"]
+  - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways/finalizers", "httproutes/finalizers"]
     verbs: ["update"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+## CLUSTER ROLE BINDINGS
 ---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "certManager.name.controller" . }}-issuers
+  labels:
+    app.kubernetes.io/component: "controller"
+    {{- include "certManager.defaultLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "certManager.name.controller" . }}-issuers
+subjects:
+  - name: {{ template "certManager.name.controller" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "certManager.name.controller" . }}-clusterissuers
+  labels:
+    app.kubernetes.io/component: "controller"
+    {{- include "certManager.defaultLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "certManager.name.controller" . }}-clusterissuers
+subjects:
+  - name: {{ template "certManager.name.controller" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "certManager.name.controller" . }}-certificates
+  labels:
+    app.kubernetes.io/component: "controller"
+    {{- include "certManager.defaultLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "certManager.name.controller" . }}-certificates
+subjects:
+  - name: {{ template "certManager.name.controller" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "certManager.name.controller" . }}-orders
+  labels:
+    app.kubernetes.io/component: "controller"
+    {{- include "certManager.defaultLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "certManager.name.controller" . }}-orders
+subjects:
+  - name: {{ template "certManager.name.controller" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "certManager.name.controller" . }}-challenges
+  labels:
+    app.kubernetes.io/component: "controller"
+    {{- include "certManager.defaultLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "certManager.name.controller" . }}-challenges
+subjects:
+  - name: {{ template "certManager.name.controller" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "certManager.name.controller" . }}-ingress-shim
+  labels:
+    app.kubernetes.io/component: "controller"
+    {{- include "certManager.defaultLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "certManager.name.controller" . }}-ingress-shim
+subjects:
+  - name: {{ template "certManager.name.controller" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "certManager.name" . }}-view
   labels:
     app.kubernetes.io/component: "controller"
+    {{- if .Values.global.rbac.aggregateClusterRoles }}
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- end }}
     {{- include "certManager.defaultLabels" . | nindent 4 }}
 rules:
   - apiGroups: ["cert-manager.io"]
@@ -217,24 +380,34 @@ rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["challenges", "orders"]
     verbs: ["get", "list", "watch"]
+
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "certManager.name" . }}-edit
   labels:
     app.kubernetes.io/component: "controller"
+    {{- if .Values.global.rbac.aggregateClusterRoles }}
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- end }}
     {{- include "certManager.defaultLabels" . | nindent 4 }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests", "issuers"]
     verbs: ["create", "delete", "deletecollection", "patch", "update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates/status"]
+    verbs: ["update"]
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["challenges", "orders"]
     verbs: ["create", "delete", "deletecollection", "patch", "update"]
+
 ---
+
 # Permission to approve CertificateRequests referencing cert-manager.io Issuers and ClusterIssuers
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -248,7 +421,27 @@ rules:
     resources: ["signers"]
     verbs: ["approve"]
     resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]
+
 ---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "certManager.name" . }}-controller-approve:cert-manager-io
+  labels:
+    app.kubernetes.io/component: "controller"
+    {{- include "certManager.defaultLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "certManager.name" . }}-controller-approve:cert-manager-io
+subjects:
+  - name: {{ template "certManager.name.controller" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+
+---
+
 # Permission to:
 # - Update and sign CertificatSigningeRequests referencing cert-manager.io Issuers and ClusterIssuers
 # - Perform SubjectAccessReviews to test whether users are able to reference Namespaced Issuers
@@ -265,7 +458,7 @@ rules:
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["certificates.k8s.io"]
     resources: ["signers"]
     resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]
@@ -274,121 +467,8 @@ rules:
     resources: ["subjectaccessreviews"]
     verbs: ["create"]
 
-## CLUSTER ROLE BINDINGS
+---
 
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ template "certManager.name.controller" . }}-issuers
-  labels:
-    app.kubernetes.io/component: "controller"
-    {{- include "certManager.defaultLabels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "certManager.name.controller" . }}-issuers
-subjects:
-  - name: {{ template "certManager.name.controller" . }}
-    namespace: {{ .Release.Namespace | quote }}
-    kind: ServiceAccount
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ template "certManager.name.controller" . }}-clusterissuers
-  labels:
-    app.kubernetes.io/component: "controller"
-    {{- include "certManager.defaultLabels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "certManager.name.controller" . }}-clusterissuers
-subjects:
-  - name: {{ template "certManager.name.controller" . }}
-    namespace: {{ .Release.Namespace | quote }}
-    kind: ServiceAccount
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ template "certManager.name.controller" . }}-certificates
-  labels:
-    app.kubernetes.io/component: "controller"
-    {{- include "certManager.defaultLabels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "certManager.name.controller" . }}-certificates
-subjects:
-  - name: {{ template "certManager.name.controller" . }}
-    namespace: {{ .Release.Namespace | quote }}
-    kind: ServiceAccount
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ template "certManager.name.controller" . }}-orders
-  labels:
-    app.kubernetes.io/component: "controller"
-    {{- include "certManager.defaultLabels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "certManager.name.controller" . }}-orders
-subjects:
-  - name: {{ template "certManager.name.controller" . }}
-    namespace: {{ .Release.Namespace | quote }}
-    kind: ServiceAccount
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ template "certManager.name.controller" . }}-challenges
-  labels:
-    app.kubernetes.io/component: "controller"
-    {{- include "certManager.defaultLabels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "certManager.name.controller" . }}-challenges
-subjects:
-  - name: {{ template "certManager.name.controller" . }}
-    namespace: {{ .Release.Namespace | quote }}
-    kind: ServiceAccount
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ template "certManager.name.controller" . }}-ingress-shim
-  labels:
-    app.kubernetes.io/component: "controller"
-    {{- include "certManager.defaultLabels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "certManager.name.controller" . }}-ingress-shim
-subjects:
-  - name: {{ template "certManager.name.controller" . }}
-    namespace: {{ .Release.Namespace | quote }}
-    kind: ServiceAccount
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ template "certManager.name" . }}-controller-approve:cert-manager-io
-  labels:
-    app.kubernetes.io/component: "controller"
-    {{- include "certManager.defaultLabels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "certManager.name" . }}-controller-approve:cert-manager-io
-subjects:
-  - name: {{ template "certManager.name.controller" . }}
-    namespace: {{ .Release.Namespace | quote }}
-    kind: ServiceAccount
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -404,55 +484,3 @@ subjects:
   - name: {{ template "certManager.name.controller" . }}
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
-
-## ROLES
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ template "certManager.name.controller" . }}:leaderelection
-  namespace: {{ .Release.Namespace | quote }}
-  labels:
-    app.kubernetes.io/component: "controller"
-    {{- include "certManager.defaultLabels" . | nindent 4 }}
-rules:
-  # Used for leader election by the controller
-  # See also: https://github.com/kubernetes-sigs/controller-runtime/pull/1144#discussion_r480173688
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    resourceNames: ["cert-manager-controller"]
-    verbs: ["get", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["create"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    resourceNames: ["cert-manager-controller"]
-    verbs: ["get", "update", "patch"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["create"]
-
-## ROLE BINDINGS
-
----
-# grant cert-manager permission to manage the leaderelection configmap in the
-# leader election namespace
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ template "certManager.name.controller" . }}:leaderelection
-  namespace: {{ .Release.Namespace | quote }}
-  labels:
-    app.kubernetes.io/component: "controller"
-    {{- include "certManager.defaultLabels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ template "certManager.name.controller" . }}:leaderelection
-subjects:
-  - apiGroup: ""
-    kind: ServiceAccount
-    name: {{ template "certManager.name.controller" . }}
-    namespace: {{ .Release.Namespace | quote }}

--- a/helm/cert-manager-app/templates/controller-serviceaccount.yaml
+++ b/helm/cert-manager-app/templates/controller-serviceaccount.yaml
@@ -7,3 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/component: "controller"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
+    {{- with .Values.controller.serviceAccount.labels }}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}

--- a/helm/cert-manager-app/templates/startupapicheck-serviceaccount.yaml
+++ b/helm/cert-manager-app/templates/startupapicheck-serviceaccount.yaml
@@ -16,6 +16,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "startupapicheck"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
+    {{- with .Values.startupapicheck.serviceAccount.labels }}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
 {{- end }}

--- a/helm/cert-manager-app/templates/webhook-serviceaccount.yaml
+++ b/helm/cert-manager-app/templates/webhook-serviceaccount.yaml
@@ -7,3 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/component: "webhook"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
+    {{- with .Values.webhook.serviceAccount.labels }}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}

--- a/helm/cert-manager-app/values.schema.json
+++ b/helm/cert-manager-app/values.schema.json
@@ -43,6 +43,9 @@
                     "properties": {
                         "automountServiceAccountToken": {
                             "type": "boolean"
+                        },
+                        "labels": {
+                            "type": "object"
                         }
                     }
                 }
@@ -111,6 +114,9 @@
                     "properties": {
                         "automountServiceAccountToken": {
                             "type": "boolean"
+                        },
+                        "labels": {
+                            "type": "object"
                         }
                     }
                 }
@@ -325,6 +331,9 @@
                         },
                         "name": {
                             "type": "string"
+                        },
+                        "labels": {
+                            "type": "object"
                         }
                     }
                 },
@@ -411,6 +420,9 @@
                     "properties": {
                         "automountServiceAccountToken": {
                             "type": "boolean"
+                        },
+                        "labels": {
+                            "type": "object"
                         }
                     }
                 },

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -42,6 +42,8 @@ cainjector:
       memory: 32Mi
 
   serviceAccount:
+    # Optional additional labels to add to the cainjector's ServiceAccount
+    # labels: {}
     automountServiceAccountToken: true
 
 # controller
@@ -105,6 +107,8 @@ controller:
       memory: 100Mi
 
   serviceAccount:
+    # Optional additional labels to add to the controller's ServiceAccount
+    # labels: {}
     automountServiceAccountToken: true
 
 # crds
@@ -188,7 +192,7 @@ global:
     # cert-manager version.
     # IMPORTANT: this should not be changed.
     # NOTE: When upgrading, make sure to reflect the change in Chart.yaml metadata too.
-    version: v1.7.3
+    version: v1.8.2
 
   # global.name
   # Set the name stub used in all resources. If not set, the Helm release
@@ -207,6 +211,10 @@ global:
 
     # global.securityContext.runAsNonRoot
     runAsNonRoot: true
+
+  rbac:
+    # Aggregate ClusterRoles to Kubernetes default user-facing roles. Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
+    aggregateClusterRoles: true
 
 # prometheus
 prometheus:
@@ -294,6 +302,8 @@ webhook:
   validatingWebhookConfigurationAnnotations: {}
 
   serviceAccount:
+    # Optional additional labels to add to the webhook's ServiceAccount
+    # labels: {}
     automountServiceAccountToken: true
 
   # webhook.url
@@ -370,6 +380,9 @@ startupapicheck:
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     # name: ""
+
+    # Optional additional labels to add to the startupapicheck's ServiceAccount
+    # labels: {}
 
     # Optional additional annotations to add to the Job's ServiceAccount
     annotations:


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/organizational-structure/teams/halo/app-testing/cert-manager/
-->

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- updates controller components to v1.8.2
- aligns the rbac file to upstream for better comparison

### Testing

#### Optional app

- [x] fresh install
- [x] upgrade from previous version

#### Pre-installed app

- [x] fresh install during cluster creation
- [x] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install nginx-ingress-controller-app and hello-world-app to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [x] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

