### PR TITLE
Add TTL to installation job, default to 30 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add TTL to CRD installation job, defaults to 30 (seconds)
+
 ## [2.16.0] - 2022-09-12
 
 Before you upgrade to this release, make sure to read the [Upgrading from v1.7 to v1.8](https://cert-manager.io/docs/installation/upgrading/upgrading-1.7-1.8/) document.

--- a/helm/cert-manager-app/templates/crd-install/crd-job.yaml
+++ b/helm/cert-manager-app/templates/crd-install/crd-job.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- include "certManager.defaultLabels" . | nindent 4 }}
     role: "{{ template "certManager.CRDInstallSelector" . }}"
 spec:
+  ttlSecondsAfterFinished: {{ .Values.crds.installationJob.ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:

--- a/helm/cert-manager-app/templates/crd-install/crd-job.yaml
+++ b/helm/cert-manager-app/templates/crd-install/crd-job.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "certManager.defaultLabels" . | nindent 4 }}
     role: "{{ template "certManager.CRDInstallSelector" . }}"
 spec:
-  ttlSecondsAfterFinished: {{ .Values.crds.installationJob.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.crds.ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:

--- a/helm/cert-manager-app/values.schema.json
+++ b/helm/cert-manager-app/values.schema.json
@@ -139,6 +139,14 @@
                 "install": {
                     "type": "boolean"
                 },
+                "installationJob": {
+                    "type": "object",
+                    "properties": {
+                        "ttlSecondsAfterFinished": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "resources": {
                     "type": "object",
                     "properties": {

--- a/helm/cert-manager-app/values.schema.json
+++ b/helm/cert-manager-app/values.schema.json
@@ -139,13 +139,8 @@
                 "install": {
                     "type": "boolean"
                 },
-                "installationJob": {
-                    "type": "object",
-                    "properties": {
-                        "ttlSecondsAfterFinished": {
-                            "type": "integer"
-                        }
-                    }
+                "ttlSecondsAfterFinished": {
+                    "type": "integer"
                 },
                 "resources": {
                     "type": "object",

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -131,11 +131,9 @@ crds:
   # be managed by another method.
   install: true
 
-  # crd.installationJob
-  installationJob:
-    # crd.installationJob.ttlSecondsAfterFinished
-    # Time after the job gets automatically cleaned up by kubernetes.
-    ttlSecondsAfterFinished: 30
+  # crd.ttlSecondsAfterFinished
+  # Time after the installation job gets automatically cleaned up by kubernetes.
+  ttlSecondsAfterFinished: 30
 
   # crds.resources
   resources:

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -131,6 +131,12 @@ crds:
   # be managed by another method.
   install: true
 
+  # crd.installationJob
+  installationJob:
+    # crd.installationJob.ttlSecondsAfterFinished
+    # Time after the job gets automatically cleaned up by kubernetes.
+    ttlSecondsAfterFinished: 30
+
   # crds.resources
   resources:
 


### PR DESCRIPTION
Related to:  https://github.com/giantswarm/giantswarm/issues/23325

This PR:

- Add TTL to CRD installation job, defaults to 30 seconds

### Testing

#### Optional app

- [ ] fresh install
- [ ] upgrade from previous version

#### Pre-installed app

- [ ] fresh install during cluster creation
- [ ] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install nginx-ingress-controller-app and hello-world-app to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [ ] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

