### PR TITLE
add-caprivate-giantswarm-issuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add private selfigned CA issuer for private clusters.
+
 ## [2.18.0] - 2022-11-14
 
 ### Added

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/_helpers.tpl
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/_helpers.tpl
@@ -47,4 +47,33 @@ metadata:
     giantswarm.io/service-type: "managed"
 spec:
   selfSigned: {}
+{{- if .Values.global.privateIssuer.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: private-giantswarm
+  labels:
+    giantswarm.io/service-type: "managed"
+spec:
+  ca:
+    secretName: private-giantswarm-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: private-giantswarm-ca
+  namespace: kube-system
+spec:
+  isCA: true
+  commonName: gigantic.internal
+  secretName: private-giantswarm-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-giantswarm
+    kind: ClusterIssuer
+    group: cert-manager.io
+{{- end }}
 {{- end }}

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/clusterrole.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/clusterrole.yaml
@@ -20,6 +20,7 @@ rules:
   - cert-manager.io
   resources:
   - clusterissuers
+  - certificates
   verbs:
   - create
   - get

--- a/helm/cert-manager-app/values.schema.json
+++ b/helm/cert-manager-app/values.schema.json
@@ -239,6 +239,14 @@
                 "name": {
                     "type": "string"
                 },
+		"privateIssuer": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "rbac": {
                     "type": "object",
                     "properties": {

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -212,6 +212,10 @@ global:
     # global.securityContext.runAsNonRoot
     runAsNonRoot: true
 
+  # global.privateIssuer
+  privateIssuer:
+    # global.privateIssuer.enabled
+    enabled: false
   rbac:
     # Aggregate ClusterRoles to Kubernetes default user-facing roles. Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
     aggregateClusterRoles: true


### PR DESCRIPTION
add option to create a proper selfisigned issuer with CA necesery for private clusters
