### PR TITLE
Update: default irsa role for cert-manager-controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- IRSA role for `cert-manager-controller`
+
 ## [2.20.0] - 2023-02-20
 
 ### Added

--- a/helm/cert-manager-app/templates/_helpers.tpl
+++ b/helm/cert-manager-app/templates/_helpers.tpl
@@ -108,7 +108,7 @@ Set the role name for IRSA
 {{- if .Values.controller.aws.role }}
 {{- printf "%s" .Values.controller.aws.role }}
 {{- else }}
-{{- printf "%s-Route53Manager-Role" .Values.clusterID }}
+{{- printf "%s-CertManager-Role" .Values.clusterID }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
This PR:
Towards - https://github.com/giantswarm/roadmap/issues/1981

Updates the IAM role used when using IRSA/

### Checklist

- [ ] Update changelog in CHANGELOG.md.

