### PR TITLE
Add CircleCI context to fix build of tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ workflows:
       # deploy to all installations (only tags)
       - architect/push-to-app-collection:
           name: push-cert-manager-app-to-shared-app-collection
+          context: architect
           app_name: "cert-manager-app"
           app_namespace: "kube-system"
           app_collection_repo: "shared-app-collection"
@@ -60,6 +61,7 @@ workflows:
       # deploy to aws installations (only tags)
       - architect/push-to-app-collection:
           name: push-cert-manager-app-to-aws-app-collection
+          context: architect
           app_name: "cert-manager-app"
           app_namespace: "kube-system"
           app_collection_repo: "aws-app-collection"
@@ -74,6 +76,7 @@ workflows:
       # deploy to azure installations (only tags)
       - architect/push-to-app-collection:
           name: push-cert-manager-app-to-azure-app-collection
+          context: architect
           app_name: "cert-manager-app"
           app_namespace: "kube-system"
           app_collection_repo: "azure-app-collection"


### PR DESCRIPTION
Tested via temporary tag: https://app.circleci.com/pipelines/github/giantswarm/cert-manager-app/1279/workflows/cb8af0e6-5952-42d6-8fad-3811ea1a2d7c

This fixes `CATALOGBOT_SSH_KEY_PRIVATE_BASE64 env variable must not be empty`.

### Checklist

- [ ] Update changelog in CHANGELOG.md.