### PR TITLE
Always install giantswarm-selfsigned ClusterIssuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Install `giantswarm-selfsigned` ClusterIssuer regardless of `global.giantSwarmClusterIssuer.install` value. It is required as a default component for Giant Swarm cluster installations.
+
 ## [2.21.0] - 2023-04-04
 
 ### Added

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/_helpers.tpl
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/_helpers.tpl
@@ -9,6 +9,7 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 {{- end -}}
 
 {{- define "clusterIssuer" }}
+{{- if .Values.global.giantSwarmClusterIssuer.install }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -50,6 +51,7 @@ spec:
           class: nginx
     {{ end }}
 ---
+{{- end }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/clusterrole.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.giantSwarmClusterIssuer.install }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -24,4 +23,3 @@ rules:
   - create
   - get
   - patch
-{{- end }}

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/clusterrolebinding.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/clusterrolebinding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.giantSwarmClusterIssuer.install }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -15,4 +14,3 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.name }}
   namespace: {{ .Release.Namespace }}
-{{- end }}

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/configmap.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.giantSwarmClusterIssuer.install }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,4 +9,3 @@ metadata:
 data:
   clusterissuer.yaml: |
 {{ include "clusterIssuer" . | indent 4 }}
-{{- end }}

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/job.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/job.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.giantSwarmClusterIssuer.install }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -42,4 +41,3 @@ spec:
         effect: NoSchedule
       - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
-{{- end }}

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/networkpolicy.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/networkpolicy.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.giantSwarmClusterIssuer.install }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -16,4 +15,3 @@ spec:
   - Egress
   egress:
   - {}
-{{- end }}

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/podsecuritypolicy.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/podsecuritypolicy.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.giantSwarmClusterIssuer.install }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -38,4 +37,3 @@ spec:
   allowPrivilegeEscalation: false
   seLinux:
     rule: RunAsAny
-{{- end }}

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/serviceaccount.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.giantSwarmClusterIssuer.install }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,4 +6,3 @@ metadata:
     {{- include "issuerLabels" . | nindent 4 }}
   annotations:
     {{- include "issuerAnnotations" . | nindent 4 }}
-{{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27170

This PR changes installation of the `giantswarm-selfsigned` ClusterIssuer regardless of `global.giantSwarmClusterIssuer.install` value. It is required as a default component for Giant Swarm cluster installations.

Regarding cert-manager-app chart installations using the cert-manager controller flag `--namespace`: Specifying this flag makes the controller ignore ClusterIssuers.

```
      --namespace string                                    If set, this limits the scope of cert-manager to a single namespace and ClusterIssuers are disabled. If not specified, all namespaces will be watched
```

### Checklist

- [x] Update changelog in CHANGELOG.md.

