### PR TITLE
Prevent installation of PodSecurityPolicies on k8s 1.25

### DIFF
--- a/.ats/main.yaml
+++ b/.ats/main.yaml
@@ -1,6 +1,6 @@
 smoke-tests-cluster-type: kind
 
-skip-steps: [functional]
+skip-steps: [functional, upgrade]
 
 upgrade-tests-cluster-type: kind
 upgrade-tests-app-catalog-url: https://giantswarm.github.io/giantswarm-catalog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,8 @@ workflows:
 
       - architect/run-tests-with-ats:
           name: execute chart tests
+          app-test-suite_version: "v0.3.0"
+          app-test-suite_container_tag: "0.3.0"
           filters:
             # Do not trigger the job on merge to main.
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ workflows:
           name: execute chart tests
           app-test-suite_version: "v0.3.0"
           app-test-suite_container_tag: "0.3.0"
+          additional_app-test-suite_flags: "--kind-cluster-image kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
           filters:
             # Do not trigger the job on merge to main.
             branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Do not try to install PodSecurityPolicies if not available. This will make the Chart compatible with kubernetes >= 1.25 ([#321](https://github.com/giantswarm/cert-manager-app/pull/321))
+
 ## [2.22.0] - 2023-06-07
 
 ### Changed

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/clusterrole.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/clusterrole.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "issuerAnnotations" . | nindent 4 }}
 rules:
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 - apiGroups:
   - policy
   resources:
@@ -15,6 +16,7 @@ rules:
   - {{ .Values.name }}
   verbs:
   - use
+{{ end }}
 - apiGroups:
   - cert-manager.io
   resources:

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/podsecuritypolicy.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/podsecuritypolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -37,3 +38,4 @@ spec:
   allowPrivilegeEscalation: false
   seLinux:
     rule: RunAsAny
+{{- end }}

--- a/helm/cert-manager-app/templates/cainjector-psp.yaml
+++ b/helm/cert-manager-app/templates/cainjector-psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -35,3 +36,4 @@ spec:
   volumes:
     - 'downwardAPI'
     - 'secret'
+{{- end }}

--- a/helm/cert-manager-app/templates/cainjector-rbac-psp.yaml
+++ b/helm/cert-manager-app/templates/cainjector-rbac-psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -31,3 +32,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "certManager.name.cainjector" . }}
     namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/helm/cert-manager-app/templates/controller-psp.yaml
+++ b/helm/cert-manager-app/templates/controller-psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -36,3 +37,4 @@ spec:
     - 'downwardAPI'
     - 'secret'
     - 'projected'
+{{- end }}

--- a/helm/cert-manager-app/templates/controller-rbac-psp.yaml
+++ b/helm/cert-manager-app/templates/controller-rbac-psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -30,3 +31,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "certManager.controller.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/helm/cert-manager-app/templates/crd-install/clusterrole.yaml
+++ b/helm/cert-manager-app/templates/crd-install/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.crds.install) (.Capabilities.APIVersions.Has "policy/v1beta1") -}}
+{{- if .Values.crds.install -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -9,6 +9,7 @@ metadata:
   annotations:
     {{- include "certManager.CRDInstallAnnotations" . | nindent 4 }}
 rules:
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 - apiGroups:
   - policy
   resources:
@@ -17,6 +18,7 @@ rules:
   - {{ template "certManager.name.crdInstall" . }}
   verbs:
   - use
+{{ end }}
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/helm/cert-manager-app/templates/crd-install/clusterrole.yaml
+++ b/helm/cert-manager-app/templates/crd-install/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crds.install }}
+{{- if and (.Values.crds.install) (.Capabilities.APIVersions.Has "policy/v1beta1") -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/cert-manager-app/templates/crd-install/podsecuritypolicy.yaml
+++ b/helm/cert-manager-app/templates/crd-install/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crds.install }}
+{{- if and (.Values.crds.install) (.Capabilities.APIVersions.Has "policy/v1beta1") -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helm/cert-manager-app/templates/startupapicheck-psp-clusterrole.yaml
+++ b/helm/cert-manager-app/templates/startupapicheck-psp-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.startupapicheck.enabled -}}
+{{- if and (.Values.startupapicheck.enabled) (.Capabilities.APIVersions.Has "policy/v1beta1") -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/helm/cert-manager-app/templates/startupapicheck-psp.yaml
+++ b/helm/cert-manager-app/templates/startupapicheck-psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.startupapicheck.enabled -}}
+{{- if and (.Values.startupapicheck.enabled) (.Capabilities.APIVersions.Has "policy/v1beta1") -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helm/cert-manager-app/templates/webhook-psp.yaml
+++ b/helm/cert-manager-app/templates/webhook-psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -35,3 +36,4 @@ spec:
   volumes:
     - 'downwardAPI'
     - 'secret'
+{{- end }}

--- a/helm/cert-manager-app/templates/webhook-rbac-psp.yaml
+++ b/helm/cert-manager-app/templates/webhook-rbac-psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -30,3 +31,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "certManager.name.webhook" . }}
     namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/tests/ats/Pipfile
+++ b/tests/ats/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [packages]
-pytest-helm-charts = ">=0.7.0"
+pytest-helm-charts = ">=1.0.2"
 pytest = ">=6.2.5"
 pykube-ng = ">=21.10.0"
 pytest-rerunfailures = ">=10.2"

--- a/tests/ats/Pipfile.lock
+++ b/tests/ats/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c306716d4e617df758d2324e1423b4de565bec4f4dc9f509eb5922ee7900ff41"
+            "sha256": "ce7cc16f8a28cec1e5f825b543997625bb51f874d11fc587aa72b01cc0a34af1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,14 +16,6 @@
         ]
     },
     "default": {
-        "attrs": {
-            "hashes": [
-                "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04",
-                "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==23.1.0"
-        },
         "certifi": {
             "hashes": [
                 "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7",
@@ -115,11 +107,19 @@
         },
         "deprecated": {
             "hashes": [
-                "sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d",
-                "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"
+                "sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c",
+                "sha256:e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.2.13"
+            "version": "==1.2.14"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e",
+                "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.1.1"
         },
         "idna": {
             "hashes": [
@@ -153,45 +153,37 @@
             "markers": "python_version >= '3.6'",
             "version": "==1.0.0"
         },
-        "py": {
-            "hashes": [
-                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
-                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.11.0"
-        },
         "pykube-ng": {
             "hashes": [
-                "sha256:5218a55f8d0cdfa1cc6974e9ec95915d60e42ccb195c62098d08eae692cfa69f",
-                "sha256:bee3c758ad8a1c9950cb11f86394a4a37aea865a08bb81aabfb682deca3f600d"
+                "sha256:1cd761ed9c7768958fdb92a404b53a5b2b26f71314bbd1c5d1fcf4f45896e2c0",
+                "sha256:6f414281d4ec64800aaa9603c0eeeff5d591072efddf8c5faaa483f7dbc828d8"
             ],
             "index": "pypi",
-            "version": "==22.1.0"
+            "version": "==22.9.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
-                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
+                "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295",
+                "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"
             ],
             "index": "pypi",
-            "version": "==6.2.5"
+            "version": "==7.3.2"
         },
         "pytest-helm-charts": {
             "hashes": [
-                "sha256:17592d6b118b7808f68059e44fae528278e7ac8a4972cb5512f3a149a0e1db28",
-                "sha256:f31617c50212f81c2d471c2bd4abe59be42b1cff09c5f2acb94344b7adc674df"
+                "sha256:3315679d0852f65e34ef8b39fcd65a14e9e83b9d65b4274a70efe4c06b57e715",
+                "sha256:f865e09468f0c7f3308e2b88ed713c92d5707231572553ad1bd5cffe5f851655"
             ],
             "index": "pypi",
-            "version": "==0.7.0"
+            "version": "==1.1.1"
         },
         "pytest-rerunfailures": {
             "hashes": [
-                "sha256:9e1e1bad51e07642c5bbab809fc1d4ec8eebcb7de86f90f1a26e6ef9de446697",
-                "sha256:d31d8e828dfd39363ad99cd390187bf506c7a433a89f15c3126c7d16ab723fe2"
+                "sha256:55611661e873f1cafa384c82f08d07883954f4b76435f4b8a5b470c1954573de",
+                "sha256:d21fe2e46d9774f8ad95f1aa799544ae95cac3a223477af94aa985adfae92b7e"
             ],
             "index": "pypi",
-            "version": "==10.2"
+            "version": "==11.1.2"
         },
         "pyyaml": {
             "hashes": [
@@ -244,32 +236,24 @@
                 "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
                 "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==2.31.0"
         },
-        "setuptools": {
+        "tomli": {
             "hashes": [
-                "sha256:5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f",
-                "sha256:62642358adc77ffa87233bc4d2354c4b2682d214048f500964dbe760ccedf102"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==67.8.0"
-        },
-        "toml": {
-            "hashes": [
-                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
-            ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.10.2"
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc",
-                "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"
+                "sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1",
+                "sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.2"
+            "version": "==2.0.3"
         },
         "wrapt": {
             "hashes": [

--- a/tests/ats/test_basic_cluster.py
+++ b/tests/ats/test_basic_cluster.py
@@ -15,32 +15,6 @@ namespace_name = "default"
 timeout: int = 360
 
 
-@pytest.mark.smoke
-def test_api_working(kube_cluster: Cluster) -> None:
-    """Very minimalistic example of using the [kube_cluster](pytest_helm_charts.fixtures.kube_cluster)
-    fixture to get an instance of [Cluster](pytest_helm_charts.clusters.Cluster) under test
-    and access its [kube_client](pytest_helm_charts.clusters.Cluster.kube_client) property
-    to get access to Kubernetes API of cluster under test.
-    Please refer to [pykube](https://pykube.readthedocs.io/en/latest/api/pykube.html) to get docs
-    for [HTTPClient](https://pykube.readthedocs.io/en/latest/api/pykube.html#pykube.http.HTTPClient).
-    """
-    assert kube_cluster.kube_client is not None
-    assert len(pykube.Node.objects(kube_cluster.kube_client)) >= 1
-
-
-@pytest.mark.smoke
-def test_cluster_info(
-    kube_cluster: Cluster, cluster_type: str, chart_extra_info: Dict[str, str]
-) -> None:
-    """Example shows how you can access additional information about the cluster the tests are running on"""
-    logger.info(f"Running on cluster type {cluster_type}")
-    key = "external_cluster_type"
-    if key in chart_extra_info:
-        logger.info(f"{key} is {chart_extra_info[key]}")
-    assert kube_cluster.kube_client is not None
-    assert cluster_type != ""
-
-
 # scope "module" means this is run only once, for the first test case requesting! It might be tricky
 # if you want to assert this multiple times
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-hydra will be automatically requested for review once
this PR has been submitted.
-->

This PR prevents installation of PodSecurityPolicies on clusters running kubernetes 1.25 and above.

It also updates some testing depencencies.

### Checklist

- [x] Update changelog in CHANGELOG.md.

