### PR TITLE
PodSecurityPolicy: Set `allowedProfileNames`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- PodSecurityPolicy: Set `allowedProfileNames`. ([#326](https://github.com/giantswarm/cert-manager-app/pull/326))
+
 ## [2.23.0] - 2023-06-14
 
 ### Changed

--- a/helm/cert-manager-app/templates/crd-install/podsecuritypolicy.yaml
+++ b/helm/cert-manager-app/templates/crd-install/podsecuritypolicy.yaml
@@ -8,6 +8,9 @@ metadata:
     app.kubernetes.io/component: crd-install
   annotations:
     {{- include "certManager.CRDInstallAnnotations" . | nindent 4 }}
+    {{- if .Values.global.securityContext.seccompProfile }}
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: "*"
+    {{- end }}
 spec:
   privileged: false
   hostPID: false


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-hydra will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- adds/changes/removes etc

### Testing

#### Optional app

- [x] fresh install
- [x] upgrade from previous version

#### Pre-installed app

- [x] fresh install during cluster creation
- [x] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install nginx-ingress-controller-app and hello-world-app to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [x] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

