### PR TITLE
PodSecurityPolicy: Set `allowedProfileNames`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- PodSecurityPolicy: Set `allowedProfileNames`. ([#328](https://github.com/giantswarm/cert-manager-app/pull/328))
+
 ## [2.23.1] - 2023-06-19
 
 ### Changed

--- a/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/podsecuritypolicy.yaml
+++ b/helm/cert-manager-app/charts/cert-manager-giantswarm-clusterissuer/templates/podsecuritypolicy.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- include "issuerLabels" . | nindent 4 }}
   annotations:
     {{- include "issuerAnnotations" . | nindent 4 }}
+    {{- if .Values.global.securityContext.seccompProfile }}
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: "*"
+    {{- end }}
 spec:
   privileged: false
   hostPID: false

--- a/helm/cert-manager-app/templates/cainjector-psp.yaml
+++ b/helm/cert-manager-app/templates/cainjector-psp.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     app.kubernetes.io/component: "cainjector"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
+  {{- if .Values.global.securityContext.seccompProfile }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: "*"
+  {{- end }}
 spec:
   allowedCapabilities: [] # drop default capabilities
   allowPrivilegeEscalation: false

--- a/helm/cert-manager-app/templates/controller-psp.yaml
+++ b/helm/cert-manager-app/templates/controller-psp.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     app.kubernetes.io/component: "controller"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
+  {{- if .Values.global.securityContext.seccompProfile }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: "*"
+  {{- end }}
 spec:
   allowedCapabilities: [] # drop default capabilities
   allowPrivilegeEscalation: false

--- a/helm/cert-manager-app/templates/webhook-psp.yaml
+++ b/helm/cert-manager-app/templates/webhook-psp.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     app.kubernetes.io/component: "webhook"
     {{- include "certManager.defaultLabels" . | nindent 4 }}
+  {{- if .Values.global.securityContext.seccompProfile }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: "*"
+  {{- end }}
 spec:
   allowedCapabilities: [] # drop default capabilities
   allowPrivilegeEscalation: false


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-hydra will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- adds/changes/removes etc

### Testing

#### Optional app

- [x] fresh install
- [x] upgrade from previous version

#### Pre-installed app

- [x] fresh install during cluster creation
- [x] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install nginx-ingress-controller-app and hello-world-app to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [x] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

