### PR TITLE
Add `cluster-autoscaler safe-to-evict` annotation to `controller` and `cainjector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Add `cluster-autoscaler safe-to-evict` annotation to `controller` and `cainjector`. ([#330](https://github.com/giantswarm/cert-manager-app/pull/330))
+- Add `cluster-autoscaler safe-to-evict` annotation to `controller` and `cainjector` through newly introduced `controller.podAnnotations` and `cainjector.podAnnotations` values. ([#330](https://github.com/giantswarm/cert-manager-app/pull/330))
 
 ## [2.24.0] - 2023-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Add `cluster-autoscaler safe-to-evict` annotation to `controller` and `cainjector`
+- Add `cluster-autoscaler safe-to-evict` annotation to `controller` and `cainjector`. ([#330](https://github.com/giantswarm/cert-manager-app/pull/330))
 
 ## [2.23.2] - 2023-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add `cluster-autoscaler safe-to-evict` annotation to `controller` and `cainjector`
+
 ## [2.23.2] - 2023-06-19
 
 ### Changed

--- a/helm/cert-manager-app/templates/cainjector-deployment.yaml
+++ b/helm/cert-manager-app/templates/cainjector-deployment.yaml
@@ -19,6 +19,10 @@ spec:
       labels:
         app.kubernetes.io/component: "cainjector"
         {{- include "certManager.defaultLabels" . | nindent 8 }}
+{{- if eq ( .Values.cainjector.replicas | toString ) "1" }}
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+{{- end }}
     spec:
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/helm/cert-manager-app/templates/cainjector-deployment.yaml
+++ b/helm/cert-manager-app/templates/cainjector-deployment.yaml
@@ -19,10 +19,10 @@ spec:
       labels:
         app.kubernetes.io/component: "cainjector"
         {{- include "certManager.defaultLabels" . | nindent 8 }}
-{{- if eq ( .Values.cainjector.replicas | toString ) "1" }}
+      {{- if not (empty .Values.cainjector.podAnnotations) }}
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
-{{- end }}
+        {{- toYaml .Values.cainjector.podAnnotations | nindent 8 }}  
+      {{- end }}
     spec:
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/helm/cert-manager-app/templates/controller-deployment.yaml
+++ b/helm/cert-manager-app/templates/controller-deployment.yaml
@@ -28,8 +28,8 @@ spec:
       {{- if .Values.controller.aws.role }}
         iam.amazonaws.com/role: {{ .Values.controller.aws.role }}
       {{- end }}
-      {{- if eq (.Values.controller.replicas | toString ) "1" }}
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      {{- if not ( empty .Values.controller.podAnnotations ) }}
+      {{- toYaml .Values.controller.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
       tolerations:

--- a/helm/cert-manager-app/templates/controller-deployment.yaml
+++ b/helm/cert-manager-app/templates/controller-deployment.yaml
@@ -28,6 +28,9 @@ spec:
       {{- if .Values.controller.aws.role }}
         iam.amazonaws.com/role: {{ .Values.controller.aws.role }}
       {{- end }}
+      {{- if eq (.Values.controller.replicas | toString ) "1" }}
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      {{- end }}
     spec:
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/helm/cert-manager-app/values.schema.json
+++ b/helm/cert-manager-app/values.schema.json
@@ -25,6 +25,9 @@
                 "logLevel": {
                     "type": ["null", "string"]
                 },
+                "podAnnotations": {
+                    "type": "object"
+                },
                 "replicas": {
                     "type": "integer"
                 },
@@ -125,6 +128,9 @@
                 },
                 "logLevel": {
                     "type": ["null", "string"]
+                },
+                "podAnnotations": {
+                    "type": "object"
                 },
                 "replicas": {
                     "type": "integer"

--- a/helm/cert-manager-app/values.yaml
+++ b/helm/cert-manager-app/values.yaml
@@ -30,6 +30,10 @@ cainjector:
   # is active at one time.
   replicas: 1
 
+  podAnnotations:
+    # When using single replica we need to annotate the pod for Cluster Autoscaler to allow eviction in kube-system namespace
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+
   # cainjector.resources
   resources:
     # cainjector.resources.requests
@@ -90,6 +94,10 @@ controller:
   # How many replicas of the controller to run. Controllers hold elections and only one
   # is active at one time.
   replicas: 1
+
+  podAnnotations:
+    # When using single replica we need to annotate the pod for Cluster Autoscaler to allow eviction in kube-system namespace
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 
   # controller.resources
   resources:


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-hydra will be automatically requested for review once
this PR has been submitted.
-->

Towards https://github.com/giantswarm/vodafone/issues/617

This PR:

- Add `cluster-autoscaler safe-to-evict` annotation to `controller` and `cainjector`

### Testing

#### Optional app

- [ ] fresh install
- [ ] upgrade from previous version

#### Pre-installed app

- [ ] fresh install during cluster creation
- [ ] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install nginx-ingress-controller-app and hello-world-app to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [ ] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.

