### PR TITLE
Add helm adoption annotations to CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add helm adoption annotations to CRD templates. This change is done in preparation of the next major chart release. ([#331](https://github.com/giantswarm/cert-manager-app/pull/331))
+
 ## [2.23.2] - 2023-06-19
 
 ### Changed

--- a/helm/cert-manager-app/files/certificaterequests.yaml
+++ b/helm/cert-manager-app/files/certificaterequests.yaml
@@ -4,6 +4,8 @@ metadata:
   name: certificaterequests.cert-manager.io
   annotations:
     cert-manager.io/inject-ca-from-secret: '{{ .Release.Namespace }}/{{ template "certManager.name.webhook" . }}-ca'
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "certManager.CRDLabels" . | nindent 4 }}
     app.kubernetes.io/version: "v1.12.1"

--- a/helm/cert-manager-app/files/certificates.yaml
+++ b/helm/cert-manager-app/files/certificates.yaml
@@ -4,6 +4,8 @@ metadata:
   name: certificates.cert-manager.io
   annotations:
     cert-manager.io/inject-ca-from-secret: '{{ .Release.Namespace }}/{{ template "certManager.name.webhook" . }}-ca'
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "certManager.CRDLabels" . | nindent 4 }}
     app.kubernetes.io/version: "v1.12.1"

--- a/helm/cert-manager-app/files/challenges.yaml
+++ b/helm/cert-manager-app/files/challenges.yaml
@@ -4,6 +4,8 @@ metadata:
   name: challenges.acme.cert-manager.io
   annotations:
     cert-manager.io/inject-ca-from-secret: '{{ .Release.Namespace }}/{{ template "certManager.name.webhook" . }}-ca'
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "certManager.CRDLabels" . | nindent 4 }}
     app.kubernetes.io/version: "v1.12.1"

--- a/helm/cert-manager-app/files/clusterissuers.yaml
+++ b/helm/cert-manager-app/files/clusterissuers.yaml
@@ -4,6 +4,8 @@ metadata:
   name: clusterissuers.cert-manager.io
   annotations:
     cert-manager.io/inject-ca-from-secret: '{{ .Release.Namespace }}/{{ template "certManager.name.webhook" . }}-ca'
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "certManager.CRDLabels" . | nindent 4 }}
     app.kubernetes.io/version: "v1.12.1"

--- a/helm/cert-manager-app/files/issuers.yaml
+++ b/helm/cert-manager-app/files/issuers.yaml
@@ -4,6 +4,8 @@ metadata:
   name: issuers.cert-manager.io
   annotations:
     cert-manager.io/inject-ca-from-secret: '{{ .Release.Namespace }}/{{ template "certManager.name.webhook" . }}-ca'
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "certManager.CRDLabels" . | nindent 4 }}
     app.kubernetes.io/version: "v1.12.1"

--- a/helm/cert-manager-app/files/orders.yaml
+++ b/helm/cert-manager-app/files/orders.yaml
@@ -4,6 +4,8 @@ metadata:
   name: orders.acme.cert-manager.io
   annotations:
     cert-manager.io/inject-ca-from-secret: '{{ .Release.Namespace }}/{{ template "certManager.name.webhook" . }}-ca'
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "certManager.CRDLabels" . | nindent 4 }}
     app.kubernetes.io/version: "v1.12.1"


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-hydra will be automatically requested for review once
this PR has been submitted.
-->

This PR adds helm annotations to CRDs. This change is done in preparation for a future major release of the chart.

### Testing

#### Pre-installed app

- [x] fresh install during cluster creation
- [x] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install nginx-ingress-controller-app and hello-world-app to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [x] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

