### PR TITLE
Make Deployment names predictable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Update container image versions to use [v1.12.3](https://github.com/cert-manager/cert-manager/releases/tag/v1.12.3) ([#344](https://github.com/giantswarm/cert-manager-app/pull/344))
 - Fix PodDisruptionBudget templates for simultaneous minAvailable and maxUnavailable null values. ([#344](https://github.com/giantswarm/cert-manager-app/pull/344))
+- Make resource names less long through default values change. ([#343](https://github.com/giantswarm/cert-manager-app/pull/343))
 
 ## [3.0.1] - 2023-07-26
 

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -723,3 +723,5 @@ startupapicheck:
 
 ciliumNetworkPolicy:
   enabled: false
+
+fullnameOverride: "cert-manager"

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -724,4 +724,4 @@ startupapicheck:
 ciliumNetworkPolicy:
   enabled: false
 
-fullnameOverride: "cert-manager"
+fullnameOverride: "cert-manager-app"

--- a/tests/ats/test_basic_cluster.py
+++ b/tests/ats/test_basic_cluster.py
@@ -21,7 +21,7 @@ timeout: int = 360
 def app_deployment(kube_cluster: Cluster) -> List[pykube.Deployment]:
     deployments = wait_for_deployments_to_run(
         kube_cluster.kube_client,
-        ["cert-manager-app-cainjector", "cert-manager-app", "cert-manager-app-webhook"],
+        ["cert-manager-cainjector", "cert-manager", "cert-manager-webhook"],
         "default",
         timeout,
     )

--- a/tests/ats/test_basic_cluster.py
+++ b/tests/ats/test_basic_cluster.py
@@ -21,7 +21,7 @@ timeout: int = 360
 def app_deployment(kube_cluster: Cluster) -> List[pykube.Deployment]:
     deployments = wait_for_deployments_to_run(
         kube_cluster.kube_client,
-        ["cert-manager-cainjector", "cert-manager", "cert-manager-webhook"],
+        ["cert-manager-app-cainjector", "cert-manager-app", "cert-manager-app-webhook"],
         "default",
         timeout,
     )


### PR DESCRIPTION
This PR adds `fullnameOverride: 'cert-manager-app'` to default values.

This will make sure Deployment names will be 
```
cert-manager-app
cert-manager-app-cainjector
cert-manager-app-webhook
```

### Checklist

- [x] Update changelog in CHANGELOG.md.

