### PR TITLE
Configurable serviceLinks + Update from upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+⚠️ Attention: Major release [3.0.0](#300---2023-07-26) contains breaking changes in user values! Please make yourself familiar with its changelog! ⚠️
+
+### Changed
+
+- Make `spec.enableServiceLinks` field configurable for controller, cainjector and webhook Deployments and startupapicheck Job. ([#350](https://github.com/giantswarm/cert-manager-app/pull/350))
+- Update chart from upstream. Relevant upstream PRs: [#6241](https://github.com/cert-manager/cert-manager/pull/6241), [#6156](https://github.com/cert-manager/cert-manager/pull/6156), [#6292](https://github.com/cert-manager/cert-manager/pull/6292), [#5337](https://github.com/cert-manager/cert-manager/pull/5337). ([#350](https://github.com/giantswarm/cert-manager-app/pull/350))
+
 ## [3.1.0] - 2023-07-27
 
 ⚠️ Attention: Major release [3.0.0](#300---2023-07-26) contains breaking changes in user values! Please make yourself familiar with its changelog! ⚠️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ⚠️ Attention: Major release [3.0.0](#300---2023-07-26) contains breaking changes in user values! Please make yourself familiar with its changelog! ⚠️
 
-## Changed
+### Changed
 
 - Update container image versions to use [v1.12.3](https://github.com/cert-manager/cert-manager/releases/tag/v1.12.3) ([#344](https://github.com/giantswarm/cert-manager-app/pull/344))
 - Fix PodDisruptionBudget templates for simultaneous minAvailable and maxUnavailable null values. ([#344](https://github.com/giantswarm/cert-manager-app/pull/344))
@@ -28,7 +28,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ⚠️ Attention: Major release [3.0.0](#300---2023-07-26) contains breaking changes in user values! Please make yourself familiar with its changelog! ⚠️
 
-## Changed
+### Changed
 
 - Explicitly set `ciliumNetworkPolicy.enabled` to `false` in default values. ([#341](https://github.com/giantswarm/cert-manager-app/pull/341))
 

--- a/helm/cert-manager/templates/cainjector-deployment.yaml
+++ b/helm/cert-manager/templates/cainjector-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- if hasKey .Values.cainjector "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.cainjector.automountServiceAccountToken }}
       {{- end }}
-      enableServiceLinks: false
+      enableServiceLinks: {{ .Values.cainjector.enableServiceLinks }}
       {{- with .Values.global.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}

--- a/helm/cert-manager/templates/deployment.yaml
+++ b/helm/cert-manager/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
       {{- if hasKey .Values "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- end }}
-      enableServiceLinks: false
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- with .Values.global.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
@@ -60,9 +60,16 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.volumes }}
+      {{- if or .Values.volumes .Values.config}}
       volumes:
+        {{- if .Values.config }} 
+        - name: config 
+          configMap: 
+            name: {{ include "cert-manager.fullname" . }} 
+        {{- end }}
+        {{ with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-controller
@@ -74,6 +81,10 @@ spec:
           {{- if .Values.global.logLevel }}
           - --v={{ .Values.global.logLevel }}
           {{- end }}
+          {{- if .Values.config }}
+          - --config=/var/cert-manager/config/config.yaml
+          {{- end }}
+          {{- $config := default .Values.config "" }}
           {{- if .Values.clusterResourceNamespace }}
           - --cluster-resource-namespace={{ .Values.clusterResourceNamespace }}
           {{- else }}
@@ -134,9 +145,15 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.volumeMounts }}
+          {{- if or .Values.config .Values.volumeMounts }}
           volumeMounts:
+            {{- if .Values.config}} 
+            - name: config 
+              mountPath: /var/cert-manager/config
+            {{- end }}
+            {{- with .Values.volumeMounts }} 
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           env:
           - name: POD_NAMESPACE

--- a/helm/cert-manager/templates/rbac.yaml
+++ b/helm/cert-manager/templates/rbac.yaml
@@ -398,6 +398,26 @@ subjects:
     namespace: {{ include "cert-manager.namespace" . }}
     kind: ServiceAccount
 
+{{- if .Values.global.rbac.aggregateClusterRoles }}
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "cert-manager.fullname" . }}-cluster-view
+  labels:
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "controller"
+    {{- include "labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers"]
+    verbs: ["get", "list", "watch"]
+
+{{- end }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -414,6 +434,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     {{- end }}
 rules:
   - apiGroups: ["cert-manager.io"]

--- a/helm/cert-manager/templates/startupapicheck-job.yaml
+++ b/helm/cert-manager/templates/startupapicheck-job.yaml
@@ -37,7 +37,7 @@ spec:
       {{- if hasKey .Values.startupapicheck "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.startupapicheck.automountServiceAccountToken }}
       {{- end }}
-      enableServiceLinks: false
+      enableServiceLinks: {{ .Values.startupapicheck.enableServiceLinks }}
       {{- with .Values.global.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}

--- a/helm/cert-manager/templates/webhook-deployment.yaml
+++ b/helm/cert-manager/templates/webhook-deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{- if hasKey .Values.webhook "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.webhook.automountServiceAccountToken }}
       {{- end }}
-      enableServiceLinks: false
+      enableServiceLinks: {{ .Values.webhook.enableServiceLinks }}
       {{- with .Values.global.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
@@ -54,6 +54,9 @@ spec:
       {{- end }}
       {{- if .Values.webhook.hostNetwork }}
       hostNetwork: true
+      {{- end }}
+      {{- if .Values.webhook.hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-webhook

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -63,11 +63,11 @@ strategy: {}
 podDisruptionBudget:
   enabled: false
 
-  minAvailable: 1
-  # maxUnavailable: 1
-
   # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
   # or a percentage value (e.g. 25%)
+  # if neither minAvailable or maxUnavailable is set, we default to `minAvailable: 1`
+  minAvailable: 1
+  # maxUnavailable: 1
 
 # Comma separated list of feature gates that should be enabled on the
 # controller pod.
@@ -116,6 +116,29 @@ serviceAccount:
 
 # When this flag is enabled, secrets will be automatically removed when the certificate resource is deleted
 enableCertificateOwnerRef: false
+
+# Used to configure options for the controller pod.
+# This allows setting options that'd usually be provided via flags.
+# An APIVersion and Kind must be specified in your values.yaml file.
+# Flags will override options that are set here.
+config:
+#   apiVersion: controller.config.cert-manager.io/v1alpha1
+#   kind: ControllerConfiguration
+#   logging:
+#    verbosity: 2
+#    format: text
+#   leaderElectionConfig:
+#    namespace: kube-system
+#   kubernetesAPIQPS: 9000
+#   kubernetesAPIBurst: 9000
+#   numberOfConcurrentWorkers: 200
+#   featureGates:
+#     additionalCertificateOutputFormats: true
+#     experimentalCertificateSigningRequestControllers: true
+#     experimentalGatewayAPISupport: true
+#     serverSideApply: true
+#     literalCertificateSubject: true
+#     useCertificateRequestBasicConstraints: true
 
 # Setting Nameservers for DNS01 Self Check
 # See: https://cert-manager.io/docs/configuration/acme/dns01/#setting-nameservers-for-dns01-self-check
@@ -214,6 +237,7 @@ prometheus:
     labels: {}
     annotations: {}
     honorLabels: false
+    endpointAdditionalProperties: {}
 
 # Use these variables to configure the HTTP_PROXY environment variables
 # http_proxy: "http://proxy:8080"
@@ -274,6 +298,11 @@ livenessProbe:
   successThreshold: 1
   failureThreshold: 8
 
+# enableServiceLinks indicates whether information about services should be
+# injected into pod's environment variables, matching the syntax of Docker
+# links.
+enableServiceLinks: false
+
 webhook:
   replicaCount: 2
   timeoutSeconds: 10
@@ -311,11 +340,11 @@ webhook:
   podDisruptionBudget:
     enabled: true
 
-    minAvailable: "50%"
-    # maxUnavailable: 1
-
     # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
     # or a percentage value (e.g. 25%)
+    # if neither minAvailable or maxUnavailable is set, we default to `minAvailable: 1`
+    minAvailable: "50%"
+    # maxUnavailable: 1
 
   # Container Security Context to be set on the webhook component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -494,6 +523,11 @@ webhook:
   volumes: []
   volumeMounts: []
 
+  # enableServiceLinks indicates whether information about services should be
+  # injected into pod's environment variables, matching the syntax of Docker
+  # links.
+  enableServiceLinks: false
+
 cainjector:
   enabled: true
   replicaCount: 1
@@ -514,11 +548,11 @@ cainjector:
   podDisruptionBudget:
     enabled: false
 
-    minAvailable: 1
-    # maxUnavailable: 1
-
     # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
     # or a percentage value (e.g. 25%)
+    # if neither minAvailable or maxUnavailable is set, we default to `minAvailable: 1`
+    minAvailable: 1
+    # maxUnavailable: 1
 
   # Container Security Context to be set on the cainjector component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -596,6 +630,11 @@ cainjector:
 
   volumes: []
   volumeMounts: []
+
+  # enableServiceLinks indicates whether information about services should be
+  # injected into pod's environment variables, matching the syntax of Docker
+  # links.
+  enableServiceLinks: false
 
 acmesolver:
   image:
@@ -720,6 +759,11 @@ startupapicheck:
 
   volumes: []
   volumeMounts: []
+
+  # enableServiceLinks indicates whether information about services should be
+  # injected into pod's environment variables, matching the syntax of Docker
+  # links.
+  enableServiceLinks: false
 
 ciliumNetworkPolicy:
   enabled: false

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,8 +2,8 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Update CRDs from upstream
-      sha: 9378b2e56460c17addaf07f187312f1097e8a95a
+      commitTitle: Merge branch 'upstream-master'
+      sha: afc706b771124c200f94264417956529a26c21a3
     path: cert-manager
   path: vendor
 - contents:


### PR DESCRIPTION
This PR syncs the chart template code with upstream

- Make `spec.enableServiceLinks` field configurable for controller, cainjector and webhook Deployments and startupapicheck Job. ([#350](https://github.com/giantswarm/cert-manager-app/pull/350))
- Update chart from upstream. Relevant upstream PRs: [#6241](https://github.com/cert-manager/cert-manager/pull/6241), [#6156](https://github.com/cert-manager/cert-manager/pull/6156), [#6292](https://github.com/cert-manager/cert-manager/pull/6292), [#5337](https://github.com/cert-manager/cert-manager/pull/5337). ([#350](https://github.com/giantswarm/cert-manager-app/pull/350))


