### PR TITLE
Add NetworkPolicies for controller and cainjector pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+⚠️ Attention: Major release [3.0.0](#300---2023-07-26) contains breaking changes in user values! Please make yourself familiar with its changelog! ⚠️
+
+### Added
+
+- Add NetworkPolicies for controller and cainjector. ([#354](https://github.com/giantswarm/cert-manager-app/pull/354))
+
 ## [3.2.1] - 2023-08-29
 
 ⚠️ Attention: Major release [3.0.0](#300---2023-07-26) contains breaking changes in user values! Please make yourself familiar with its changelog! ⚠️

--- a/helm/cert-manager/templates/cainjector-networkpolicy.yaml
+++ b/helm/cert-manager/templates/cainjector-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "cainjector.fullname" . }}-cainjector-allow-egress
+  namespace: {{ include "cert-manager.namespace" . }}
+spec:
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 53
+      protocol: TCP
+    - port: 53
+      protocol: UDP
+    - port: 6443
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+  podSelector:
+    matchLabels:
+      app: {{ include "cainjector.name" . }}
+      app.kubernetes.io/name: {{ include "cainjector.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: "cainjector"
+  policyTypes:
+  - Egress

--- a/helm/cert-manager/templates/networkpolicy.yaml
+++ b/helm/cert-manager/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "cert-manager.fullname" . }}-allow-egress
+  namespace: {{ include "cert-manager.namespace" . }}
+spec:
+  egress:
+  - {}
+  ingress:
+  - ports:
+    - port: 9402
+      protocol: TCP
+    - port: 9403
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: {{ template "cert-manager.name" . }}
+      app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: "controller"
+  policyTypes:
+  - Ingress
+  - Egress


### PR DESCRIPTION
This PR adds two new NetworkPolicies for controller and cainjector. Its pods require egress and api server access.