### PR TITLE
Add job that waits for cilium CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add job that waits for the `ciliumnetworkpolicies.cilium.io` CRD to be present.
+
 ## [3.3.0] - 2023-08-29
 
 ⚠️ Attention: Major release [3.0.0](#300---2023-07-26) contains breaking changes in user values! Please make yourself familiar with its changelog! ⚠️

--- a/helm/cert-manager/Chart.yaml
+++ b/helm/cert-manager/Chart.yaml
@@ -15,5 +15,5 @@ dependencies:
     version: 2.0.0
     alias: giantSwarmClusterIssuer
   - name: cert-manager-giantswarm-netpol
-    version: 0.1.0
+    version: 0.2.0
     condition: ciliumNetworkPolicy.enabled

--- a/helm/cert-manager/charts/cert-manager-giantswarm-netpol/Chart.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-netpol/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cert-manager-giantswarm-netpol
 description: Creates the Giant Swarm network policies for cert-manager.
-version: 0.1.0
+version: 0.2.0
 home: https://github.com/giantswarm/cert-manager-app
 icon: https://s.giantswarm.io/app-icons/cert-manager/1/light.svg
 sources:

--- a/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-job.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-job.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "1"
+    helm.sh/hook-weight: "-1"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 50

--- a/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-job.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-job.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: waitforcilium
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 50
+  template:
+    metadata:
+      labels:
+        {{- include "labels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: waitforcilium
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: wait-for-cilium-crds
+          image: "quay.io/giantswarm/docker-kubectl:1.24.4"
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 100m
+              memory: 50Mi
+            limits:
+              cpu: 200m
+              memory: 100Mi
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            runAsNonRoot: true
+          command:
+            - sh
+          args:
+            - -c
+            - |
+              kubectl wait --timeout=5m --for=condition=established crd ciliumnetworkpolicies.cilium.io
+              kubectl wait --timeout=1m --for=condition=established crd ciliumclusterwidenetworkpolicies.cilium.io

--- a/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-psp.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-psp.yaml
@@ -1,0 +1,64 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: waitforcilium
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'projected'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: waitforcilium-psp
+  labels:
+    {{- include "labels" . | nindent 4 }}
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+      - waitforcilium
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: waitforcilium-psp
+  labels:
+    {{- include "labels" . | nindent 4 }}
+roleRef:
+  kind: ClusterRole
+  name: waitforcilium-psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: waitforcilium
+    namespace: {{ .Release.Namespace }}

--- a/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-psp.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-psp.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "0"
+    helm.sh/hook-weight: "-2"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   privileged: false
@@ -41,6 +41,10 @@ metadata:
   name: waitforcilium-psp
   labels:
     {{- include "labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups: ['policy']
     resources: ['podsecuritypolicies']
@@ -54,6 +58,10 @@ metadata:
   name: waitforcilium-psp
   labels:
     {{- include "labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   kind: ClusterRole
   name: waitforcilium-psp

--- a/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-rbac.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: waitforcilium
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: waitforcilium
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: waitforcilium
+subjects:
+  - kind: ServiceAccount
+    name: waitforcilium
+    namespace: {{ .Release.Namespace }}

--- a/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-rbac.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "0"
+    helm.sh/hook-weight: "-2"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -25,7 +25,7 @@ metadata:
     {{- include "labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "0"
+    helm.sh/hook-weight: "-2"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-rbac.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-rbac.yaml
@@ -15,6 +15,7 @@ rules:
       - customresourcedefinitions
     verbs:
       - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-serviceaccount.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: waitforcilium
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded

--- a/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-serviceaccount.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/waitforcilium-serviceaccount.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "0"
+    helm.sh/hook-weight: "-2"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27963

Some times we witness some weirdness going on when creating new clusters due to the fact that cert-manager fails to get installed while `cilium` is not deployed in the cluster. In this PR I'm adding a pre-install job that checks for cilium CRDs to be present before deploying the app, to make that dependency explicit.

Thoughts?

Usually what happens is that the app platform tries to deploy cert-manager but this fails due to the missing cilium CRDs, and we need to wait another whole 5 minutes before the next `chart-operator` reconciliation before cert-manager is deployed again. With this job, I'm hoping to speed things up.

### Checklist

- [X] Update changelog in CHANGELOG.md.

