### PR TITLE
Enable ServiceMonitor by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add `Values.global.podSecurityStandards.enforced` flag in preparation of PSP to PSS migration
 
+### Changed
+
+- Enable ServiceMonitor by default.
+
 ## [3.3.0] - 2023-08-29
 
 ⚠️ Attention: Major release [3.0.0](#300---2023-07-26) contains breaking changes in user values! Please make yourself familiar with its changelog! ⚠️

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -200,14 +200,10 @@ podAnnotations:
 podLabels: {}
 
 # Optional annotations to add to the controller Service
-serviceAnnotations:
-  giantswarm.io/monitoring-app-label: cert-manager-app
-  giantswarm.io/monitoring-path: /metrics
-  giantswarm.io/monitoring-port: "9402"
+# serviceAnnotations: {}
 
 # Optional additional labels to add to the controller Service
-serviceLabels:
-  giantswarm.io/monitoring: "true"
+# serviceLabels: {}
 
 # Optional DNS settings, useful if you have a public and private DNS zone for
 # the same domain on Route 53. What follows is an example of ensuring
@@ -231,7 +227,7 @@ ingressShim: {}
 prometheus:
   enabled: true
   servicemonitor:
-    enabled: false
+    enabled: true
     prometheusInstance: default
     targetPort: 9402
     path: /metrics
@@ -240,7 +236,24 @@ prometheus:
     labels: {}
     annotations: {}
     honorLabels: false
-    endpointAdditionalProperties: {}
+    endpointAdditionalProperties:
+      relabelings:
+      - action: replace
+        regex: ;(.*)
+        replacement: $1
+        separator: ;
+        sourceLabels:
+        - namespace
+        - __meta_kubernetes_namespace
+        targetLabel: namespace
+      - action: replace
+        sourceLabels:
+        - __meta_kubernetes_pod_label_app
+        targetLabel: app
+      - action: replace
+        sourceLabels:
+        - __meta_kubernetes_pod_node_name
+        targetLabel: node
 
 # Use these variables to configure the HTTP_PROXY environment variables
 # http_proxy: "http://proxy:8080"


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-hydra will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- changes the monitoring setup to use a servicemonitor instead of service annotations

### Testing

#### Optional app

- [ ] fresh install
- [ ] upgrade from previous version

#### Pre-installed app

- [ ] fresh install during cluster creation
- [ ] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install ingress-nginx and hello-world to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [ ] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

