### PR TITLE
PDB percentages & More than 1 replicas for HA

### DIFF
--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -55,7 +55,7 @@ global:
 
 installCRDs: true
 
-replicaCount: 2
+replicaCount: 1
 
 strategy: {}
   # type: RollingUpdate

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -323,7 +323,7 @@ livenessProbe:
 enableServiceLinks: false
 
 webhook:
-  replicaCount: 2
+  replicaCount: 1
   timeoutSeconds: 10
 
   # Used to configure options for the webhook pod.

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -55,7 +55,7 @@ global:
 
 installCRDs: true
 
-replicaCount: 1
+replicaCount: 2
 
 strategy: {}
   # type: RollingUpdate
@@ -69,7 +69,7 @@ podDisruptionBudget:
   # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
   # or a percentage value (e.g. 25%)
   # if neither minAvailable or maxUnavailable is set, we default to `minAvailable: 1`
-  minAvailable: 1
+  minAvailable: "50%"
   # maxUnavailable: 1
 
 # Comma separated list of feature gates that should be enabled on the
@@ -552,7 +552,7 @@ webhook:
 
 cainjector:
   enabled: true
-  replicaCount: 1
+  replicaCount: 2
 
   strategy: {}
     # type: RollingUpdate
@@ -573,7 +573,7 @@ cainjector:
     # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
     # or a percentage value (e.g. 25%)
     # if neither minAvailable or maxUnavailable is set, we default to `minAvailable: 1`
-    minAvailable: 1
+    minAvailable: "50%"
     # maxUnavailable: 1
 
   # Container Security Context to be set on the cainjector component container


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-bigmac will be automatically requested for review once
this PR has been submitted.
-->

This PR:


-  Changes the Pod Disruption Budget (PDB) to percentage-based to allow for more flexible and resilient deployments, following cloud-native best practices.


<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
