### PR TITLE
Release v3.4.1

### DIFF
--- a/.github/workflows/zz_generated.create_release_pr.yaml
+++ b/.github/workflows/zz_generated.create_release_pr.yaml
@@ -227,4 +227,5 @@ jobs:
           base: "${{ needs.gather_facts.outputs.base }}"
           version: "${{ needs.gather_facts.outputs.version }}"
         run: |
+          apt install hub
           hub pull-request -f -m "Release v${{ env.version }}" -a ${{ github.actor }} -b ${{ env.base }} -h ${{ needs.gather_facts.outputs.branch }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [3.4.1] - 2023-10-10
 
+## [3.4.1] - 2023-10-10
+
 ### Changed
 
 - Move cert-manager ownership to team BigMac. ([#349](https://github.com/giantswarm/cert-manager-app/pull/349))
@@ -542,6 +544,7 @@ Before you upgrade to this release, make sure to read the [Upgrading from v1.7 t
 - `cert-manager` upstream helm chart `v0.9.0`. ([#1](https://github.com/giantswarm/cert-manager-app/pull/1))
 
 [Unreleased]: https://github.com/giantswarm/cert-manager-app/compare/v3.4.1...HEAD
+[3.4.1]: https://github.com/giantswarm/cert-manager-app/compare/v3.4.1...v3.4.1
 [3.4.1]: https://github.com/giantswarm/cert-manager-app/compare/v3.4.0...v3.4.1
 [3.4.0]: https://github.com/giantswarm/cert-manager-app/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/giantswarm/cert-manager-app/compare/v3.2.1...v3.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+## [3.4.1] - 2023-10-10
+
 ### Changed
 
 - Move cert-manager ownership to team BigMac. ([#349](https://github.com/giantswarm/cert-manager-app/pull/349))
@@ -539,7 +541,8 @@ Before you upgrade to this release, make sure to read the [Upgrading from v1.7 t
 
 - `cert-manager` upstream helm chart `v0.9.0`. ([#1](https://github.com/giantswarm/cert-manager-app/pull/1))
 
-[Unreleased]: https://github.com/giantswarm/cert-manager-app/compare/v3.4.0...HEAD
+[Unreleased]: https://github.com/giantswarm/cert-manager-app/compare/v3.4.1...HEAD
+[3.4.1]: https://github.com/giantswarm/cert-manager-app/compare/v3.4.0...v3.4.1
 [3.4.0]: https://github.com/giantswarm/cert-manager-app/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/giantswarm/cert-manager-app/compare/v3.2.1...v3.3.0
 [3.2.1]: https://github.com/giantswarm/cert-manager-app/compare/v3.2.0...v3.2.1

--- a/helm/cert-manager/Chart.yaml
+++ b/helm/cert-manager/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cert-manager-app
 description: Simplifies the process of obtaining, renewing and using certificates.
-version: 3.4.0
+version: 3.4.1
 appVersion: v1.12.4
 home: https://github.com/giantswarm/cert-manager-app
 icon: https://s.giantswarm.io/app-icons/cert-manager/1/light.svg


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-bigmac will be automatically requested for review once
this PR has been submitted.
-->

This PR:

### Changed

- Move cert-manager ownership to team BigMac. ([#349](https://github.com/giantswarm/cert-manager-app/pull/349))
- Add default cpu and memory limits to controller, cainjector and webhook deployments. ([#367](https://github.com/giantswarm/cert-manager-app/pull/367))
- Changes the Pod Disruption Budget (PDB) to percentage-based to allow for more flexible and resilient deployments, following cloud-native best practices. ([#372](https://github.com/giantswarm/cert-manager-app/pull/372))
<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
