### PR TITLE
Allow setting hostedZoneID and make AWS credentials optional for route53 DNS01 challenge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- cert-manager-giantswarm-clusterissuer: Allow setting `hostedZoneID` for `route53` DNS01 challenge.
+- cert-manager-giantswarm-clusterissuer: Make `accessKeyID` and `secretAccessKey` optional for `route53` DNS01 challenge.
+
 ## [3.4.1] - 2023-10-10
 
 ### Changed

--- a/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/templates/_helpers.tpl
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/templates/_helpers.tpl
@@ -48,10 +48,17 @@ spec:
         route53:
           region: {{ .Values.acme.dns01.route53.region }}
           role: {{ .Values.acme.dns01.route53.role }}
+          {{- if .Values.acme.dns01.route53.hostedZoneID }}
+          hostedZoneID: {{ .Values.acme.dns01.route53.hostedZoneID }}
+          {{- end }}
+          {{- if .Values.acme.dns01.route53.accessKeyID }}
           accessKeyID: {{ .Values.acme.dns01.route53.accessKeyID }}
+          {{- end }}
+          {{- if .Values.acme.dns01.route53.secretAccessKey }}
           secretAccessKeySecretRef:
             name: route53-access-key-secret
             key: secret-access-key
+          {{- end }}
     {{ end }}
     {{ if .Values.acme.http01.enabled -}}
     - http01:

--- a/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/templates/provider-route53-secret.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/templates/provider-route53-secret.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.acme.dns01.route53.enabled }}
+{{- if .Values.acme.dns01.route53.secretAccessKey }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,4 +8,5 @@ metadata:
 type: Opaque
 stringData:
   secret-access-key: {{ .Values.acme.dns01.route53.secretAccessKey }}
+{{- end }}
 {{- end }}

--- a/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/values.schema.json
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/values.schema.json
@@ -34,6 +34,9 @@
                                 "role": {
                                     "type": "string"
                                 },
+                                "hostedZoneID": {
+                                    "type": "string"
+                                },
                                 "secretAccessKey": {
                                     "type": "string"
                                 }

--- a/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/values.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/values.yaml
@@ -38,6 +38,8 @@ acme:
       region: ""
       # route53 role to assume.
       role: ""
+      # (optional) route53 hosted zone ID. Allows avoiding granting route53:ListHostedZonesByName.
+      hostedZoneID: ""
       # route53 user access key.
       accessKeyID: ""
       # route53 user secret access key.


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2698

In our EKS setup we set IAM role to the SA so we don't need AWS credentials.

Setting hostedZoneID allows more strict permissions for the role.