### PR TITLE
dir change for acme-netpolicy

### DIFF
--- a/helm/cert-manager/templates/acme-solvers-networkpolicy.yaml
+++ b/helm/cert-manager/templates/acme-solvers-networkpolicy.yaml
@@ -1,11 +1,9 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .Values.name }}-http01-solvers
+  name: cert-manager-http01-solvers
   labels:
-    {{- include "issuerLabels" . | nindent 4 }}
-  annotations:
-    {{- include "issuerAnnotations" . | nindent 4 }}
+    {{- include "labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-bigmac will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- changes the chart that deploys the `networkPolicy` for `http-acme-solvers`
<!--
Install ingress-nginx and hello-world to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [ ] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
