### PR TITLE
disable startupapicheck job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 - changes the previous `netpols` `helm chart` to be used only for `networkPolicies`
+- disables the `startup-api-check` job that waits for the webhookendpoints to become available
 
 ## [3.5.2] - 2023-11-09
 ### Changed

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -678,7 +678,7 @@ acmesolver:
 # due to the Job never being completed because the sidecar proxy does not exit.
 # See https://github.com/cert-manager/cert-manager/pull/4414 for context.
 startupapicheck:
-  enabled: true
+  enabled: false
 
   # Pod Security Context to be set on the startupapicheck component Pod
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-bigmac will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- disables the `startup-api-check` job that waits for the webhookendpoints to become available (`ClusterIssuers job` will make sure `cert-manager` stuff is working, from now on)

### Checklist

- [ ] Update changelog in CHANGELOG.md.
