### PR TITLE
update-to-v1.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update to latest `helm chart` version to `v1.13.3`
+
 ## [3.6.1] - 2023-12-06
 
 ### Changed

--- a/helm/cert-manager/Chart.yaml
+++ b/helm/cert-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cert-manager-app
 description: Simplifies the process of obtaining, renewing and using certificates.
 version: 3.6.1
-appVersion: v1.12.4
+appVersion: v1.13.3
 home: https://github.com/giantswarm/cert-manager-app
 icon: https://s.giantswarm.io/app-icons/cert-manager/1/light.svg
 sources:


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-bigmac will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- changes cert-manager helm chart version to v1.13.3

### Testing

#### Optional app

- [x] fresh install
- [x] upgrade from previous version

#### Pre-installed app

- [ ] fresh install during cluster creation
- [x] upgrade from previous version in a pre-existing cluster

### Checklist

- [x] Update changelog in CHANGELOG.md.
