### PR TITLE
azure-dns01 option on clusterissuer chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Added support for `azureDNS` dns01 challenge solver on `cluster-issuer` chart
+
 ## [3.7.1] - 2024-01-29
 
 ### Added

--- a/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/templates/_helpers.tpl
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/templates/_helpers.tpl
@@ -62,6 +62,16 @@ spec:
             key: secret-access-key
           {{- end }}
     {{ end }}
+    {{ if .Values.acme.dns01.azureDNS.enabled -}}
+    - dns01:
+        azureDNS:
+          hostedZoneName: {{ .Values.acme.dns01.azureDNS.zoneName }}
+          resourceGroupName: {{ .Values.acme.dns01.azureDNS.resourceGroupName }}
+          subscriptionID: {{ .Values.acme.dns01.azureDNS.subscriptionID }}
+          environment: {{ .Values.acme.dns01.azureDNS.environment }}
+          managedIdentity:
+            clientID: {{ .Values.acme.dns01.azureDNS.identityClientID }}
+    {{ end }}
     {{ if .Values.acme.http01.enabled -}}
     - http01:
         ingress:

--- a/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/values.schema.json
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/values.schema.json
@@ -41,6 +41,29 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "azureDNS": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "zoneName": {
+                                    "type": "string"
+                                },
+                                "resourceGroupName": {
+                                    "type": "string"
+                                },
+                                "subscriptionID": {
+                                    "type": "string"
+                                },
+                                "environment": {
+                                    "type": "string"
+                                },
+                                "identityClientID": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     }
                 },

--- a/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/values.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/values.yaml
@@ -44,6 +44,19 @@ acme:
       accessKeyID: ""
       # route53 user secret access key.
       secretAccessKey: ""
+    azureDNS:
+      enabled: false
+      # Azure DNS Zone name.
+      zoneName: ""
+      # Azure Resource Group name.
+      resourceGroupName: ""
+      # Azure Subscription ID.
+      subscriptionID: ""
+      # Azure Environment. Default is AzurePublicCloud.
+      environment: "AzurePublicCloud"
+      # Azure Identity Client ID.
+      identityClientID: ""
+
   http01:
     enabled: true
     ingressClassName: "nginx"


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-bigmac will be automatically requested for review once
this PR has been submitted.
-->
Relevant [issue](https://github.com/giantswarm/roadmap/issues/3198)

This PR:

- adds support for `AzureDNS` on `ClusterIssuer` chart so it can be used as `dns01 challenge solver`

### Testing

#### Optional app

- [ ] fresh install
- [ ] upgrade from previous version

#### Pre-installed app

- [ ] fresh install during cluster creation
- [ ] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install ingress-nginx and hello-world to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [ ] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
