### PR TITLE
bump to 1.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Changed `appVersion` to `v1.14.2`
+
 ## [3.7.3] - 2024-02-12
 
 ### Added

--- a/helm/cert-manager/Chart.yaml
+++ b/helm/cert-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cert-manager-app
 description: Simplifies the process of obtaining, renewing and using certificates.
 version: 3.7.3
-appVersion: v1.13.3
+appVersion: v1.14.2
 home: https://github.com/giantswarm/cert-manager-app
 icon: https://s.giantswarm.io/app-icons/cert-manager/1/light.svg
 sources:

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -155,11 +155,9 @@ dns01RecursiveNameserversOnly: false
 
 # Additional command line flags to pass to cert-manager controller binary.
 # To see all available flags run docker run quay.io/jetstack/cert-manager-controller:<version> --help
-extraArgs:
-  - --controllers=*,-certificaterequests-approver
-  - --feature-gates=StableCertificateRequestName=true
-  # Use this flag to enable or disable arbitrary controllers, for example, disable the CertificiateRequests approver
-  # - --controllers=*,-certificaterequests-approver
+extraArgs: []
+# Use this flag to enable or disable arbitrary controllers, for example, disable the CertificiateRequests approver
+# - --controllers=*,-certificaterequests-approver
 
 extraEnv: []
 # - name: SOME_VAR

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -155,7 +155,9 @@ dns01RecursiveNameserversOnly: false
 
 # Additional command line flags to pass to cert-manager controller binary.
 # To see all available flags run docker run quay.io/jetstack/cert-manager-controller:<version> --help
-extraArgs: []
+extraArgs:
+  - --controllers=*,-certificaterequests-approver
+  - --feature-gates=StableCertificateRequestName=true
   # Use this flag to enable or disable arbitrary controllers, for example, disable the CertificiateRequests approver
   # - --controllers=*,-certificaterequests-approver
 


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-bigmac will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- changes the cert-manager appVersion to v1.14.2(latest)

### Testing

- CAPZ
- CAPA

#### Optional app

- [x] fresh install
- [x] upgrade from previous version

#### Pre-installed app

- [x] fresh install during cluster creation
- [x] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install ingress-nginx and hello-world to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [x] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
