### PR TITLE
crd annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Added annotation `helm.sh/resource-policy: keep` on CRDs to prevent them from being pruned in an unexpected rollback event.
+
 ## [3.7.4] - 2024-03-19
 
 ### Added

--- a/helm/cert-manager/templates/crds.yaml
+++ b/helm/cert-manager/templates/crds.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     # Generated labels 
     {{- include "labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   group: cert-manager.io
   names:
@@ -208,6 +210,8 @@ metadata:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     # Generated labels 
     {{- include "labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   group: cert-manager.io
   names:
@@ -580,6 +584,8 @@ metadata:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     # Generated labels 
     {{- include "labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   group: acme.cert-manager.io
   names:
@@ -1657,6 +1663,8 @@ metadata:
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     # Generated labels 
     {{- include "labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   group: cert-manager.io
   names:
@@ -2976,6 +2984,8 @@ metadata:
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     # Generated labels 
     {{- include "labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   group: cert-manager.io
   names:
@@ -4295,6 +4305,8 @@ metadata:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     # Generated labels 
     {{- include "labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   group: acme.cert-manager.io
   names:


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-bigmac will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- adds annotation `helm.sh/resource-policy: keep` on CRDs to prevent them from being pruned in an unexpected rollback event.

### Testing

#### Optional app

- [x] fresh install
- [x] upgrade from previous version

#### Pre-installed app

- [x] fresh install during cluster creation
- [x] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install ingress-nginx and hello-world to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [x] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
