### PR TITLE
Enable VPA by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Enable VPA by default
+
 ## [3.7.6] - 2024-06-10
 
 ### Added

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -601,7 +601,7 @@ cainjector:
   # - --enable-profiling=true
 
   verticalPodAutoscaler:
-    enabled: false
+    enabled: true
 
   resources:
     requests:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30944
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-bigmac will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- Enables VPA by default

### Testing

#### Optional app

- [ ] fresh install
- [ ] upgrade from previous version

#### Pre-installed app

- [ ] fresh install during cluster creation
- [ ] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install ingress-nginx and hello-world to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [ ] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
