### PR TITLE
Set `runAsGroup` and `runAsUser` greater than zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Improves container security by setting `runAsGroup` and `runAsUser` greater than zero for all deployments.
+
 ## [3.7.7] - 2024-06-18
 
 ### Changed

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -177,6 +177,8 @@ securityContext:
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
+  runAsUser: 1000
+  runAsGroup: 1000  
 
 # Container Security Context to be set on the controller component container
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -355,6 +357,8 @@ webhook:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
+    runAsUser: 1000
+    runAsGroup: 1000  
 
   podDisruptionBudget:
     enabled: true
@@ -566,6 +570,8 @@ cainjector:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
+    runAsUser: 1000
+    runAsGroup: 1000
 
   podDisruptionBudget:
     enabled: false

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -178,7 +178,7 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
   runAsUser: 1000
-  runAsGroup: 1000  
+  runAsGroup: 1000
 
 # Container Security Context to be set on the controller component container
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -358,7 +358,7 @@ webhook:
     seccompProfile:
       type: RuntimeDefault
     runAsUser: 1000
-    runAsGroup: 1000  
+    runAsGroup: 1000
 
   podDisruptionBudget:
     enabled: true


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31165

<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-bigmac will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- Improves container security by setting `runAsGroup` and `runAsUser` greater than zero (non-root) for all deployments.
- Fixes [require-non-root-group](https://kyverno.io/policies/other/require-non-root-groups/require-non-root-groups/) policy.

### Testing

#### Optional app

- [x] fresh install
- [x] upgrade from previous version

#### Pre-installed app

- [ ] fresh install during cluster creation
- [ ] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install ingress-nginx and hello-world to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [ ] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
