### PR TITLE
Fix acme-http01-solver-image argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fix
+
+- Remove quotes from acme-http01-solver-image argument. The quotes are used when looking up the image which causes an error.
+
 ## [3.7.8] - 2024-07-03
 
 ### Added

--- a/helm/cert-manager/templates/deployment.yaml
+++ b/helm/cert-manager/templates/deployment.yaml
@@ -103,7 +103,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- with .Values.acmesolver.image }}
-          - --acme-http01-solver-image="{{ include "registry" $ }}/{{ .repository }}{{ if .digest }}@{{ .digest }}{{ else }}:{{ default $.Chart.AppVersion .tag }}{{ end }}"
+          - --acme-http01-solver-image={{ include "registry" $ }}/{{ .repository }}{{ if .digest }}@{{ .digest }}{{ else }}:{{ default $.Chart.AppVersion .tag }}{{ end }}
           {{- end }}
           {{- with .Values.extraArgs }}
           {{- toYaml . | nindent 10 }}


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-bigmac will be automatically requested for review once
this PR has been submitted.
-->

This PR:

Removes quotes from acme-http01-solver-image argument. The quotes are used when looking up the image which causes an error.

### Testing

#### Optional app

- [ ] fresh install
- [ ] upgrade from previous version

#### Pre-installed app

- [ ] fresh install during cluster creation
- [ ] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install ingress-nginx and hello-world to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [ ] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
