### PR TITLE
remove legacy in-house slo generation framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ## [Unreleased]
 
 ### Changed
+
 - Changed ownership to team Shield
+
+### Removed
+
+- Get rid of label `giantswarm.io/monitoring_basic_sli` as this slo generation label is not used anymore.
 
 ## [3.8.1] - 2024-07-30
 

--- a/helm/cert-manager/charts/cert-manager-giantswarm-ciliumnetworkpolicies/templates/_gs-helpers.tpl
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-ciliumnetworkpolicies/templates/_gs-helpers.tpl
@@ -9,7 +9,6 @@ Labels that should be added on each resource
 */}}
 {{- define "labels" -}}
 giantswarm.io/service-type: "managed"
-giantswarm.io/monitoring_basic_sli: "true"
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 {{- if eq (default "helm" .Values.creator) "helm" }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/_gs-helpers.tpl
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-netpol/templates/_gs-helpers.tpl
@@ -9,7 +9,6 @@ Labels that should be added on each resource
 */}}
 {{- define "labels" -}}
 giantswarm.io/service-type: "managed"
-giantswarm.io/monitoring_basic_sli: "true"
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 {{- if eq (default "helm" .Values.creator) "helm" }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/helm/cert-manager/templates/_gs-helpers.tpl
+++ b/helm/cert-manager/templates/_gs-helpers.tpl
@@ -10,7 +10,6 @@ Labels that should be added on each resource
 {{- define "labels" -}}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 giantswarm.io/service-type: "managed"
-giantswarm.io/monitoring_basic_sli: "true"
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 {{- if eq (default "helm" .Values.creator) "helm" }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31095

This PR:

- removes the legacy in-house slo framework as it was replaced by sloth a long time ago and is now deprecated.
- The new slo is waiting for reviews https://github.com/giantswarm/sloth-rules/pull/238

### Checklist

- [x] Update changelog in CHANGELOG.md.
