### PR TITLE
Additional `approveSignerNames` fix

### DIFF
--- a/helm/cert-manager/templates/rbac.yaml
+++ b/helm/cert-manager/templates/rbac.yaml
@@ -517,6 +517,8 @@ rules:
 
 ---
 
+{{- if not .Values.disableAutoApproval -}}
+
 # Permission to approve CertificateRequests referencing cert-manager.io Issuers and ClusterIssuers
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -532,7 +534,12 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
     verbs: ["approve"]
-    resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]
+    {{- with .Values.approveSignerNames }}
+    resourceNames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end  }}
+    {{- end }}
 
 ---
 
@@ -556,6 +563,8 @@ subjects:
     kind: ServiceAccount
 
 ---
+
+{{- end -}}
 
 # Permission to:
 # - Update and sign CertificateSigningRequests referencing cert-manager.io Issuers and ClusterIssuers

--- a/helm/cert-manager/templates/rbac.yaml
+++ b/helm/cert-manager/templates/rbac.yaml
@@ -39,10 +39,53 @@ roleRef:
   kind: Role
   name: {{ template "cert-manager.fullname" . }}:leaderelection
 subjects:
-  - apiGroup: ""
-    kind: ServiceAccount
+  - kind: ServiceAccount
     name: {{ template "cert-manager.serviceAccountName" . }}
     namespace: {{ include "cert-manager.namespace" . }}
+
+---
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "cert-manager.serviceAccountName" . }}-tokenrequest
+  namespace: {{ include "cert-manager.namespace" . }}
+  labels:
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "controller"
+    {{- include "labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    resourceNames: ["{{ template "cert-manager.serviceAccountName" . }}"]
+    verbs: ["create"]
+
+---
+
+# grant cert-manager permission to create tokens for the serviceaccount
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cert-manager.fullname" . }}-{{ template "cert-manager.serviceAccountName" .  }}-tokenrequest
+  namespace: {{ include "cert-manager.namespace" . }}
+  labels:
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "controller"
+    {{- include "labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "cert-manager.serviceAccountName" . }}-tokenrequest
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "cert-manager.serviceAccountName" . }}
+    namespace: {{ include "cert-manager.namespace" . }}
+{{- end }}
 
 ---
 
@@ -515,7 +558,7 @@ subjects:
 ---
 
 # Permission to:
-# - Update and sign CertificatSigningeRequests referencing cert-manager.io Issuers and ClusterIssuers
+# - Update and sign CertificateSigningRequests referencing cert-manager.io Issuers and ClusterIssuers
 # - Perform SubjectAccessReviews to test whether users are able to reference Namespaced Issuers
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm/cert-manager/values.schema.json
+++ b/helm/cert-manager/values.schema.json
@@ -260,6 +260,22 @@
         "deploymentAnnotations": {
             "type": "object"
         },
+        "disableAutoApproval": {
+            "type": "boolean",
+            "default": false,
+            "description": "Option to disable cert-manager's built-in auto-approver. Useful when using a different approver like approver-policy."
+        },
+        "approveSignerNames": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "default": [
+                "issuers.cert-manager.io/*",
+                "clusterissuers.cert-manager.io/*"
+            ],
+            "description": "List of signer names that cert-manager will approve by default. Empty array means ALL issuers will be auto-approved."
+        },
         "dns01RecursiveNameservers": {
             "type": "string"
         },

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -153,6 +153,10 @@ dns01RecursiveNameservers: ""
 # Enabling this option could cause the DNS01 self check to take longer due to caching performed by the recursive nameservers
 dns01RecursiveNameserversOnly: false
 
+# Option to disable cert-manager's build-in auto-approver. The auto-approver
+# approves all CertificateRequests that reference issuers matching the 'approveSignerNames'
+# option. This 'disableAutoApproval' option is useful when you want to make all approval decisions
+# using a different approver (like approver-policy - https://github.com/cert-manager/approver-policy).
 disableAutoApproval: false
 
 # List of signer names that cert-manager will approve by default. CertificateRequests

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -153,6 +153,19 @@ dns01RecursiveNameservers: ""
 # Enabling this option could cause the DNS01 self check to take longer due to caching performed by the recursive nameservers
 dns01RecursiveNameserversOnly: false
 
+disableAutoApproval: false
+
+# List of signer names that cert-manager will approve by default. CertificateRequests
+# referencing these signer names will be auto-approved by cert-manager. Defaults to just
+# approving the cert-manager.io Issuer and ClusterIssuer issuers. When set to an empty
+# array, ALL issuers will be auto-approved by cert-manager. To disable the auto-approval,
+# because eg. you are using approver-policy, you can enable 'disableAutoApproval'.
+# ref: https://cert-manager.io/docs/concepts/certificaterequest/#approval
+# +docs:property
+approveSignerNames:
+- issuers.cert-manager.io/*
+- clusterissuers.cert-manager.io/*
+
 # Additional command line flags to pass to cert-manager controller binary.
 # To see all available flags run docker run quay.io/jetstack/cert-manager-controller:<version> --help
 extraArgs: []


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-shield will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- adds the option to configure additional `approveSignerNames`

### Testing

#### Optional app

- [ ] fresh install
- [ ] upgrade from previous version

#### Pre-installed app

- [ ] fresh install during cluster creation
- [ ] upgrade from previous version in a pre-existing cluster

#### Other testing

<!--
Install ingress-nginx and hello-world to obtain a certificate,
then upgrade the cert-manager-app and ensure the CRs are still reconciled after the upgrade.
-->

- [ ] check reconciliation of existing resources after upgrading

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
