### PR TITLE
fix(cainjector/cnp): add ingress rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Added ingress rule to cainjector CiliumNetworkPolicy to allow Prometheus metrics scraping
+
 ## [3.9.1] - 2025-04-16
 
 ### Added

--- a/helm/cert-manager/charts/cert-manager-giantswarm-ciliumnetworkpolicies/templates/cainjector-ciliumnetworkpolicy.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-ciliumnetworkpolicies/templates/cainjector-ciliumnetworkpolicy.yaml
@@ -17,3 +17,7 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+        - cluster

--- a/sync/charts/cert-manager-giantswarm-ciliumnetworkpolicies/templates/cainjector-ciliumnetworkpolicy.yaml
+++ b/sync/charts/cert-manager-giantswarm-ciliumnetworkpolicies/templates/cainjector-ciliumnetworkpolicy.yaml
@@ -17,3 +17,7 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+        - cluster


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Refer to the
testing doc below and delete where appropriate.

https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/cert-manager/
-->

<!--
@team-shield will be automatically requested for review once
this PR has been submitted.
-->
Towards: https://gigantic.slack.com/archives/C02MS174K/p1756474700388769
This PR:

- adds ingress rule to cainjector CiliumNetworkPolicy to allow Prometheus metrics scraping

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
