### PR TITLE
feat: Upgrade `docker-kubectl` image to support arm64 architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `docker-kubectl` image to support arm64 architecture
+
 ## [4.1.0] - 2026-07-08
 
 ### Changed

--- a/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/Chart.yaml
+++ b/helm/cert-manager/charts/cert-manager-giantswarm-clusterissuer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cert-manager-giantswarm-clusterissuer
 description: Creates the Giant Swarm default cluster issuers.
 version: 2.0.0
-appVersion: 1.24.4
+appVersion: 1.36.2
 home: https://github.com/giantswarm/cert-manager-app
 icon: https://s.giantswarm.io/app-icons/cert-manager/1/light.svg
 sources:


### PR DESCRIPTION
See subject. A bit unusual for me to see `appVersion` used as image version, but I left it as-is.

/run app-test-suites


### Checklist

- [x] Update changelog in CHANGELOG.md.
